### PR TITLE
Fix test_get_firmware_update_notification fail

### DIFF
--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -76,7 +76,7 @@ class ComponentBase(object):
             A string containing the component firmware update notification if required.
             By default 'None' value will be used, which indicates that no actions are required
         """
-        return None
+        return 'None'
 
     def install_firmware(self, image_path):
         """

--- a/tests/component_base_test.py
+++ b/tests/component_base_test.py
@@ -1,0 +1,7 @@
+from sonic_platform_base.component_base import ComponentBase
+
+class TestComponentBase:
+
+    def test_get_firmware_update_notification(self):
+        cpnt = ComponentBase()
+        assert(cpnt.get_firmware_update_notification(None) == "None")


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Fix test_get_firmware_update_notification fail

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Erro Log:
pytest_assert(isinstance(notif, STRING_TYPE), "Component {}: Firmware update notification appears to be incorrect from image {}".format(i, image)) E Failed: Component 0: Firmware update notification appears to be incorrect from image current

Refer to API get_firmware_update_notification header, shall return 'None' instead of None.

"""
Retrieves a notification on what should be done in order to complete the component firmware update

Args:
image_path: A string, path to firmware image

Returns:
A string containing the component firmware update notification if required. By default 'None' value will be used, which indicates that no actions are required """


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Run platform_tests/api/test_component.py::TestComponentApi::test_get_firmware_update_notification with no NO api implementation.

#### Additional Information (Optional)
https://github.com/sonic-net/sonic-platform-common/pull/472
