### PR TITLE
[sonic_xcvr]Enhance to support QSFP port_id=0xC for access eeprom

### DIFF
--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -97,7 +97,7 @@ class XcvrApiFactory(object):
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
             api = Sff8636Api(xcvr_eeprom)
         # QSFP+ or QSFP
-        elif id == 0x0D or id == 0x0C:
+        elif id == 0x0d:
             revision_compliance = self._get_revision_compliance()
             if revision_compliance >= 3:
                 codes = Sff8636Codes
@@ -109,6 +109,11 @@ class XcvrApiFactory(object):
                 mem_map = Sff8436MemMap(codes)
                 xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
                 api = Sff8436Api(xcvr_eeprom)
+        elif id == 0x0c:
+            codes = Sff8436Codes
+            mem_map = Sff8436MemMap(codes)
+            xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
+            api = Sff8436Api(xcvr_eeprom)
         elif id == 0x03:
             codes = Sff8472Codes
             mem_map = Sff8472MemMap(codes)


### PR DESCRIPTION
The original commit [d1a2e17fee7](https://github.com/edge-core/sonic-platform-common/commit/d1a2e17fee79f244759ecc81ac617d40d360dd6a) is not correct for current code.

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

