### PR TITLE
Implement is_copper() api for cmis

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -703,6 +703,18 @@ class CmisApi(XcvrApi):
         else:
             return 'Unknown media interface'
 
+    def is_copper(self):
+        '''
+        Returns True if xcvr is copper, False if xcvr is optical
+        '''
+        media_type = self.get_module_media_type()
+        if media_type == 'passive_copper_media_interface' or media_type == 'base_t_media_interface':
+            return True
+        elif  media_type == 'nm_850_media_interface' or media_type == 'sm_media_interface' or media_type == 'active_cable_media_interface':
+            return False
+        else:
+            return None
+
     def is_coherent_module(self):
         '''
         Returns True if the module follow C-CMIS spec, False otherwise


### PR DESCRIPTION
It is copper for media type 'passive_copper_media_interface' and 'base_t_media_interface'.
It is optical for 'nm_850_media_interface', 'sm_media_interface' and 'active_cable_media_interface.
