### PR TITLE
Set the eeprom cache permissions to 755

### DIFF
--- a/sonic_platform_base/sonic_eeprom/eeprom_base.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_base.py
@@ -295,9 +295,21 @@ class EepromDecoder(object):
         if self.cache_name:
             F = None
             try:
+                # Ensure the directory exists
+                directory = os.path.dirname(self.cache_name)
+
+                if not os.path.exists(directory):
+                    os.makedirs(directory)
+
+                # Set directory permissions to 755
+                os.chmod(directory, 0o755)
+
                 F = open(self.cache_name, "wb")
                 F.seek(self.s)
                 F.write(e)
+
+                # Set file permissions to 755
+                os.chmod(self.cache_name, 0o755)
             except IOError as e:
                 raise IOError("Failed to write cache : %s" % (str(e)))
             finally:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
The issue arises because, after a system reboot, the permissions of /var/cache/sonic/decode-syseeprom/ or its file /var/cache/sonic/decode-syseeprom/syseeprom_cache may be incorrectly set. This misconfiguration can cause the Platform API to require root privileges for access.

This problem has been observed in various platforms, such as the AS7326_56X, where running show platform syseeprom results in errors due to permission issues.
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
To address this, it's essential to ensure that the cache directory and its files have the correct permissions set upon system startup. Implementing a fix that adjusts these permissions appropriately can prevent the Platform API from requiring root privileges, thereby resolving the issue.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Reboot and use admin account to run show platform syseeprom.
#### Additional Information (Optional)
https://github.com/sonic-net/sonic-platform-common/pull/546
