### PR TITLE
Certain VDM fields not populating after encountering KeyError on 400Z…

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -12,11 +12,73 @@ VDM_FREEZE = 128
 VDM_UNFREEZE = 0
 SYSLOG_IDENTIFIER = "CCmisApi"
 
+VDM_KEY_TO_DB_KEY_PREFIX_MAP = {
+    'Modulator Bias X/I [%]' : 'biasxi',
+    'Modulator Bias X/Q [%]' : 'biasxq',
+    'Modulator Bias X_Phase [%]' : 'biasxp',
+    'Modulator Bias Y/I [%]' : 'biasyi',
+    'Modulator Bias Y/Q [%]' : 'biasyq',
+    'Modulator Bias Y_Phase [%]' : 'biasyp',
+    'CD high granularity, short link [ps/nm]' : 'cdshort',
+    'CD low granularity, long link [ps/nm]' : 'cdlong',
+    'DGD [ps]' : 'dgd',
+    'SOPMD [ps^2]' : 'sopmd',
+    'SOP ROC [krad/s]' : 'soproc',
+    'PDL [dB]' : 'pdl',
+    'OSNR [dB]' : 'osnr',
+    'eSNR [dB]' : 'esnr',
+    'CFO [MHz]' : 'cfo',
+    'Tx Power [dBm]' : 'txcurrpower',
+    'Rx Total Power [dBm]' : 'rxtotpower',
+    'Rx Signal Power [dBm]' : 'rxsigpower'
+}
+
+VDM_SUBTYPE_IDX_MAP= {
+    1: 'highalarm',
+    2: 'lowalarm',
+    3: 'highwarning',
+    4: 'lowwarning',
+    5: 'highalarm_flag',
+    6: 'lowalarm_flag',
+    7: 'highwarning_flag',
+    8: 'lowwarning_flag'
+}
+
+
 helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 class CCmisApi(CmisApi):
     def __init__(self, xcvr_eeprom):
         super(CCmisApi, self).__init__(xcvr_eeprom)
+
+    def _update_dict_if_vdm_key_exists(self, dict_to_be_updated, new_key, vdm_dict_key, vdm_subtype_index, lane=1):
+        '''
+        This function updates the dictionary with the VDM value if the vdm_dict_key exists.
+        @param dict_to_be_updated: the dictionary to be updated.
+        @param new_key: the key to be added in dict_to_be_updated.
+        @param vdm_dict_key: lookup key in the VDM dictionary.
+        @param vdm_subtype_index: the index of the VDM subtype in the VDM page.
+            0 refers to the real time value
+            1 refers to the high alarm threshold
+            2 refers to the low alarm threshold
+            3 refers to the high warning threshold
+            4 refers to the low warning threshold
+            5 refers to the high alarm flag
+            6 refers to the low alarm flag
+            7 refers to the high warning flag
+            8 refers to the low warning flag
+        @param lane: the lane number. Default is 1.
+
+        @return: True if the key exists in the VDM dictionary, False if not.
+        '''
+        try:
+            dict_to_be_updated[new_key] = self.vdm_dict[vdm_dict_key][lane][vdm_subtype_index]
+        except KeyError:
+            dict_to_be_updated[new_key] = 'N/A'
+            helper_logger.log_debug('key {} not present in VDM'.format(new_key))
+            return False
+
+        return True
 
     def get_freq_grid(self):
         '''
@@ -377,27 +439,10 @@ class CCmisApi(CmisApi):
         ========================================================================
         """
         trans_dom = super(CCmisApi,self).get_transceiver_bulk_status()
-        try:
-            trans_dom['bias_xi'] = self.vdm_dict['Modulator Bias X/I [%]'][1][0]
-            trans_dom['bias_xq'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][0]
-            trans_dom['bias_xp'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][0]
-            trans_dom['bias_yi'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][0]
-            trans_dom['bias_yq'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][0]
-            trans_dom['bias_yp'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][0]
-            trans_dom['cd_shortlink'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][0]
-            trans_dom['cd_longlink'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][0]
-            trans_dom['dgd'] = self.vdm_dict['DGD [ps]'][1][0]
-            trans_dom['sopmd'] = self.vdm_dict['SOPMD [ps^2]'][1][0]
-            trans_dom['soproc'] = self.vdm_dict['SOP ROC [krad/s]'][1][0]
-            trans_dom['pdl'] = self.vdm_dict['PDL [dB]'][1][0]
-            trans_dom['osnr'] = self.vdm_dict['OSNR [dB]'][1][0]
-            trans_dom['esnr'] = self.vdm_dict['eSNR [dB]'][1][0]
-            trans_dom['cfo'] = self.vdm_dict['CFO [MHz]'][1][0]
-            trans_dom['tx_curr_power'] = self.vdm_dict['Tx Power [dBm]'][1][0]
-            trans_dom['rx_tot_power'] = self.vdm_dict['Rx Total Power [dBm]'][1][0]
-            trans_dom['rx_sig_power'] = self.vdm_dict['Rx Signal Power [dBm]'][1][0]
-        except KeyError:
-            pass
+
+        for vdm_key, trans_dom_key in VDM_KEY_TO_DB_KEY_PREFIX_MAP.items():
+            self._update_dict_if_vdm_key_exists(trans_dom, trans_dom_key, vdm_key, 0)
+
         trans_dom['laser_config_freq'] = self.get_laser_config_freq()
         trans_dom['laser_curr_freq'] = self.get_current_laser_freq()
         trans_dom['tx_config_power'] = self.get_tx_config_power()
@@ -515,77 +560,12 @@ class CCmisApi(CmisApi):
         ========================================================================
         """
         trans_dom_th = super(CCmisApi,self).get_transceiver_threshold_info()
-        try:
-            trans_dom_th['biasxihighalarm'] = self.vdm_dict['Modulator Bias X/I [%]'][1][1]
-            trans_dom_th['biasxilowalarm'] = self.vdm_dict['Modulator Bias X/I [%]'][1][2]
-            trans_dom_th['biasxihighwarning'] = self.vdm_dict['Modulator Bias X/I [%]'][1][3]
-            trans_dom_th['biasxilowwarning'] = self.vdm_dict['Modulator Bias X/I [%]'][1][4]
-            trans_dom_th['biasxqhighalarm'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][1]
-            trans_dom_th['biasxqlowalarm'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][2]
-            trans_dom_th['biasxqhighwarning'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][3]
-            trans_dom_th['biasxqlowwarning'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][4]
-            trans_dom_th['biasxphighalarm'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][1]
-            trans_dom_th['biasxplowalarm'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][2]
-            trans_dom_th['biasxphighwarning'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][3]
-            trans_dom_th['biasxplowwarning'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][4]
-            trans_dom_th['biasyihighalarm'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][1]
-            trans_dom_th['biasyilowalarm'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][2]
-            trans_dom_th['biasyihighwarning'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][3]
-            trans_dom_th['biasyilowwarning'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][4]
-            trans_dom_th['biasyqhighalarm'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][1]
-            trans_dom_th['biasyqlowalarm'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][2]
-            trans_dom_th['biasyqhighwarning'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][3]
-            trans_dom_th['biasyqlowwarning'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][4]
-            trans_dom_th['biasyphighalarm'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][1]
-            trans_dom_th['biasyplowalarm'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][2]
-            trans_dom_th['biasyphighwarning'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][3]
-            trans_dom_th['biasyplowwarning'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][4]
-            trans_dom_th['cdshorthighalarm'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][1]
-            trans_dom_th['cdshortlowalarm'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][2]
-            trans_dom_th['cdshorthighwarning'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][3]
-            trans_dom_th['cdshortlowwarning'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][4]
-            trans_dom_th['cdlonghighalarm'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][1]
-            trans_dom_th['cdlonglowalarm'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][2]
-            trans_dom_th['cdlonghighwarning'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][3]
-            trans_dom_th['cdlonglowwarning'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][4]
-            trans_dom_th['dgdhighalarm'] = self.vdm_dict['DGD [ps]'][1][1]
-            trans_dom_th['dgdlowalarm'] = self.vdm_dict['DGD [ps]'][1][2]
-            trans_dom_th['dgdhighwarning'] = self.vdm_dict['DGD [ps]'][1][3]
-            trans_dom_th['dgdlowwarning'] = self.vdm_dict['DGD [ps]'][1][4]
-            trans_dom_th['sopmdhighalarm'] = self.vdm_dict['SOPMD [ps^2]'][1][1]
-            trans_dom_th['sopmdlowalarm'] = self.vdm_dict['SOPMD [ps^2]'][1][2]
-            trans_dom_th['sopmdhighwarning'] = self.vdm_dict['SOPMD [ps^2]'][1][3]
-            trans_dom_th['sopmdlowwarning'] = self.vdm_dict['SOPMD [ps^2]'][1][4]
-            trans_dom_th['pdlhighalarm'] = self.vdm_dict['PDL [dB]'][1][1]
-            trans_dom_th['pdllowalarm'] = self.vdm_dict['PDL [dB]'][1][2]
-            trans_dom_th['pdlhighwarning'] = self.vdm_dict['PDL [dB]'][1][3]
-            trans_dom_th['pdllowwarning'] = self.vdm_dict['PDL [dB]'][1][4]
-            trans_dom_th['osnrhighalarm'] = self.vdm_dict['OSNR [dB]'][1][1]
-            trans_dom_th['osnrlowalarm'] = self.vdm_dict['OSNR [dB]'][1][2]
-            trans_dom_th['osnrhighwarning'] = self.vdm_dict['OSNR [dB]'][1][3]
-            trans_dom_th['osnrlowwarning'] = self.vdm_dict['OSNR [dB]'][1][4]
-            trans_dom_th['esnrhighalarm'] = self.vdm_dict['eSNR [dB]'][1][1]
-            trans_dom_th['esnrlowalarm'] = self.vdm_dict['eSNR [dB]'][1][2]
-            trans_dom_th['esnrhighwarning'] = self.vdm_dict['eSNR [dB]'][1][3]
-            trans_dom_th['esnrlowwarning'] = self.vdm_dict['eSNR [dB]'][1][4]
-            trans_dom_th['cfohighalarm'] = self.vdm_dict['CFO [MHz]'][1][1]
-            trans_dom_th['cfolowalarm'] = self.vdm_dict['CFO [MHz]'][1][2]
-            trans_dom_th['cfohighwarning'] = self.vdm_dict['CFO [MHz]'][1][3]
-            trans_dom_th['cfolowwarning'] = self.vdm_dict['CFO [MHz]'][1][4]
-            trans_dom_th['txcurrpowerhighalarm'] = self.vdm_dict['Tx Power [dBm]'][1][1]
-            trans_dom_th['txcurrpowerlowalarm'] = self.vdm_dict['Tx Power [dBm]'][1][2]
-            trans_dom_th['txcurrpowerhighwarning'] = self.vdm_dict['Tx Power [dBm]'][1][3]
-            trans_dom_th['txcurrpowerlowwarning'] = self.vdm_dict['Tx Power [dBm]'][1][4]
-            trans_dom_th['rxtotpowerhighalarm'] = self.vdm_dict['Rx Total Power [dBm]'][1][1]
-            trans_dom_th['rxtotpowerlowalarm'] = self.vdm_dict['Rx Total Power [dBm]'][1][2]
-            trans_dom_th['rxtotpowerhighwarning'] = self.vdm_dict['Rx Total Power [dBm]'][1][3]
-            trans_dom_th['rxtotpowerlowwarning'] = self.vdm_dict['Rx Total Power [dBm]'][1][4]
-            trans_dom_th['rxsigpowerhighalarm'] = self.vdm_dict['Rx Signal Power [dBm]'][1][1]
-            trans_dom_th['rxsigpowerlowalarm'] = self.vdm_dict['Rx Signal Power [dBm]'][1][2]
-            trans_dom_th['rxsigpowerhighwarning'] = self.vdm_dict['Rx Signal Power [dBm]'][1][3]
-            trans_dom_th['rxsigpowerlowwarning'] = self.vdm_dict['Rx Signal Power [dBm]'][1][4]
-        except KeyError:
-            pass
+
+        for vdm_key, trans_dom_th_key_prefix in VDM_KEY_TO_DB_KEY_PREFIX_MAP.items():
+            for i in range(1, 5):
+                trans_dom_th_key = trans_dom_th_key_prefix + VDM_SUBTYPE_IDX_MAP[i]
+                self._update_dict_if_vdm_key_exists(trans_dom_th, trans_dom_th_key, vdm_key, i)
+
         return trans_dom_th
 
     def get_transceiver_status(self):
@@ -772,77 +752,12 @@ class CCmisApi(CmisApi):
         trans_status['tuning_not_accepted'] = 'TuningNotAccepted' in laser_tuning_summary
         trans_status['invalid_channel_num'] = 'InvalidChannel' in laser_tuning_summary
         trans_status['tuning_complete'] = 'TuningComplete' in laser_tuning_summary
-        try:
-            trans_status['biasxihighalarm_flag'] = self.vdm_dict['Modulator Bias X/I [%]'][1][5]
-            trans_status['biasxilowalarm_flag'] = self.vdm_dict['Modulator Bias X/I [%]'][1][6]
-            trans_status['biasxihighwarning_flag'] = self.vdm_dict['Modulator Bias X/I [%]'][1][7]
-            trans_status['biasxilowwarning_flag'] = self.vdm_dict['Modulator Bias X/I [%]'][1][8]
-            trans_status['biasxqhighalarm_flag'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][5]
-            trans_status['biasxqlowalarm_flag'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][6]
-            trans_status['biasxqhighwarning_flag'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][7]
-            trans_status['biasxqlowwarning_flag'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][8]
-            trans_status['biasxphighalarm_flag'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][5]
-            trans_status['biasxplowalarm_flag'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][6]
-            trans_status['biasxphighwarning_flag'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][7]
-            trans_status['biasxplowwarning_flag'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][8]
-            trans_status['biasyihighalarm_flag'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][5]
-            trans_status['biasyilowalarm_flag'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][6]
-            trans_status['biasyihighwarning_flag'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][7]
-            trans_status['biasyilowwarning_flag'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][8]
-            trans_status['biasyqhighalarm_flag'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][5]
-            trans_status['biasyqlowalarm_flag'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][6]
-            trans_status['biasyqhighwarning_flag'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][7]
-            trans_status['biasyqlowwarning_flag'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][8]
-            trans_status['biasyphighalarm_flag'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][5]
-            trans_status['biasyplowalarm_flag'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][6]
-            trans_status['biasyphighwarning_flag'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][7]
-            trans_status['biasyplowwarning_flag'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][8]
-            trans_status['cdshorthighalarm_flag'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][5]
-            trans_status['cdshortlowalarm_flag'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][6]
-            trans_status['cdshorthighwarning_flag'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][7]
-            trans_status['cdshortlowwarning_flag'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][8]
-            trans_status['cdlonghighalarm_flag'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][5]
-            trans_status['cdlonglowalarm_flag'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][6]
-            trans_status['cdlonghighwarning_flag'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][7]
-            trans_status['cdlonglowwarning_flag'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][8]
-            trans_status['dgdhighalarm_flag'] = self.vdm_dict['DGD [ps]'][1][5]
-            trans_status['dgdlowalarm_flag'] = self.vdm_dict['DGD [ps]'][1][6]
-            trans_status['dgdhighwarning_flag'] = self.vdm_dict['DGD [ps]'][1][7]
-            trans_status['dgdlowwarning_flag'] = self.vdm_dict['DGD [ps]'][1][8]
-            trans_status['sopmdhighalarm_flag'] = self.vdm_dict['SOPMD [ps^2]'][1][5]
-            trans_status['sopmdlowalarm_flag'] = self.vdm_dict['SOPMD [ps^2]'][1][6]
-            trans_status['sopmdhighwarning_flag'] = self.vdm_dict['SOPMD [ps^2]'][1][7]
-            trans_status['sopmdlowwarning_flag'] = self.vdm_dict['SOPMD [ps^2]'][1][8]
-            trans_status['pdlhighalarm_flag'] = self.vdm_dict['PDL [dB]'][1][5]
-            trans_status['pdllowalarm_flag'] = self.vdm_dict['PDL [dB]'][1][6]
-            trans_status['pdlhighwarning_flag'] = self.vdm_dict['PDL [dB]'][1][7]
-            trans_status['pdllowwarning_flag'] = self.vdm_dict['PDL [dB]'][1][8]
-            trans_status['osnrhighalarm_flag'] = self.vdm_dict['OSNR [dB]'][1][5]
-            trans_status['osnrlowalarm_flag'] = self.vdm_dict['OSNR [dB]'][1][6]
-            trans_status['osnrhighwarning_flag'] = self.vdm_dict['OSNR [dB]'][1][7]
-            trans_status['osnrlowwarning_flag'] = self.vdm_dict['OSNR [dB]'][1][8]
-            trans_status['esnrhighalarm_flag'] = self.vdm_dict['eSNR [dB]'][1][5]
-            trans_status['esnrlowalarm_flag'] = self.vdm_dict['eSNR [dB]'][1][6]
-            trans_status['esnrhighwarning_flag'] = self.vdm_dict['eSNR [dB]'][1][7]
-            trans_status['esnrlowwarning_flag'] = self.vdm_dict['eSNR [dB]'][1][8]
-            trans_status['cfohighalarm_flag'] = self.vdm_dict['CFO [MHz]'][1][5]
-            trans_status['cfolowalarm_flag'] = self.vdm_dict['CFO [MHz]'][1][6]
-            trans_status['cfohighwarning_flag'] = self.vdm_dict['CFO [MHz]'][1][7]
-            trans_status['cfolowwarning_flag'] = self.vdm_dict['CFO [MHz]'][1][8]
-            trans_status['txcurrpowerhighalarm_flag'] = self.vdm_dict['Tx Power [dBm]'][1][5]
-            trans_status['txcurrpowerlowalarm_flag'] = self.vdm_dict['Tx Power [dBm]'][1][6]
-            trans_status['txcurrpowerhighwarning_flag'] = self.vdm_dict['Tx Power [dBm]'][1][7]
-            trans_status['txcurrpowerlowwarning_flag'] = self.vdm_dict['Tx Power [dBm]'][1][8]
-            trans_status['rxtotpowerhighalarm_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][5]
-            trans_status['rxtotpowerlowalarm_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][6]
-            trans_status['rxtotpowerhighwarning_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][7]
-            trans_status['rxtotpowerlowwarning_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][8]
-            trans_status['rxsigpowerhighalarm_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][5]
-            trans_status['rxsigpowerlowalarm_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][6]
-            trans_status['rxsigpowerhighwarning_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][7]
-            trans_status['rxsigpowerlowwarning_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][8]
-        except KeyError:
-            helper_logger.log_debug('fields not present in VDM')
+
+        for vdm_key, trans_status_key_prefix in VDM_KEY_TO_DB_KEY_PREFIX_MAP.items():
+            for i in range(5, 9):
+                trans_status_key = trans_status_key_prefix + VDM_SUBTYPE_IDX_MAP[i]
+                self._update_dict_if_vdm_key_exists(trans_status, trans_status_key, vdm_key, i)
+
         return trans_status
 
     def get_transceiver_pm(self):

--- a/tests/sonic_xcvr/test_ccmis.py
+++ b/tests/sonic_xcvr/test_ccmis.py
@@ -233,14 +233,14 @@ class TestCCmis(object):
                 'laser_temperature': 40,
                 'prefec_ber': 0.001,
                 'postfec_ber': 0,
-                'bias_xi': 50,
-                'bias_xq': 50,
-                'bias_xp': 50,
-                'bias_yi': 50,
-                'bias_yq': 50,
-                'bias_yp': 50,
-                'cd_shortlink': 1000,
-                'cd_longlink': 1000,
+                'biasxi': 50,
+                'biasxq': 50,
+                'biasxp': 50,
+                'biasyi': 50,
+                'biasyq': 50,
+                'biasyp': 50,
+                'cdshort': 1000,
+                'cdlong': 1000,
                 'dgd': 5,
                 'sopmd': 5,
                 'soproc': 0,
@@ -248,9 +248,9 @@ class TestCCmis(object):
                 'osnr': 30,
                 'esnr': 16,
                 'cfo': 100,
-                'tx_curr_power': -10,
-                'rx_tot_power': -10,
-                'rx_sig_power': -10,
+                'txcurrpower': -10,
+                'rxtotpower': -10,
+                'rxsigpower': -10,
                 'laser_config_freq': 193100,
                 'laser_curr_freq': 193100,
                 'tx_config_power': -10
@@ -282,6 +282,7 @@ class TestCCmis(object):
                     'lasertemphighalarm': 80, 'lasertemplowalarm': 10, 'lasertemphighwarning': 75, 'lasertemplowwarning': 20,
                     'prefecberhighalarm': 0.0125, 'prefecberlowalarm': 0, 'prefecberhighwarning': 0.01, 'prefecberlowwarning': 0,
                     'postfecberhighalarm': 1, 'postfecberlowalarm': 0, 'postfecberhighwarning': 1, 'postfecberlowwarning': 0,
+                    'soprochighalarm' : 65535, 'soproclowalarm' : 0, 'soprochighwarning' : 65535, 'soproclowwarning' : 0,
                 },
                 {
                     'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
@@ -296,13 +297,13 @@ class TestCCmis(object):
                     'CD low granularity, long link [ps/nm]':{1:[1000, 2000, 0, 1800, 0, False, False, False, False]},
                     'DGD [ps]':{1:[5, 30, 0, 25, 0, False, False, False, False]},
                     'SOPMD [ps^2]':{1:[5, 100, 0, 80, 0, False, False, False, False]},
+                    'SOP ROC [krad/s]':{1: [0, 65535, 0, 65535, 0, False, False, False, False]},
                     'PDL [dB]':{1:[0.5, 3, 0, 2.5, 0, False, False, False, False]},
                     'OSNR [dB]':{1:[30, 100, 26, 80, 27, False, False, False, False]},
                     'eSNR [dB]':{1:[16, 100, 13, 80, 14, False, False, False, False]},
                     'CFO [MHz]':{1:[100, 5000, -5000, 4000, -4000, False, False, False, False]},
                     'Tx Power [dBm]':{1:[-10, 0, -18, -2, -16, False, False, False, False]},
                     'Rx Total Power [dBm]':{1:[-10, 3, -18, 0, -15, False, False, False, False]},
-                    'Rx Signal Power [dBm]':{1:[-10, 3, -18, 0, -15, False, False, False, False]}
                 }
             ],
             {
@@ -330,7 +331,8 @@ class TestCCmis(object):
                 'cfohighalarm': 5000, 'cfolowalarm': -5000, 'cfohighwarning': 4000, 'cfolowwarning': -4000,
                 'txcurrpowerhighalarm': 0, 'txcurrpowerlowalarm': -18, 'txcurrpowerhighwarning': -2, 'txcurrpowerlowwarning': -16,
                 'rxtotpowerhighalarm': 3, 'rxtotpowerlowalarm': -18, 'rxtotpowerhighwarning': 0, 'rxtotpowerlowwarning': -15,
-                'rxsigpowerhighalarm': 3, 'rxsigpowerlowalarm': -18, 'rxsigpowerhighwarning': 0, 'rxsigpowerlowwarning': -15
+                'rxsigpowerhighalarm': 'N/A', 'rxsigpowerlowalarm': 'N/A', 'rxsigpowerhighwarning': 'N/A', 'rxsigpowerlowwarning': 'N/A',
+                'soprochighalarm': 65535, 'soproclowalarm': 0, 'soprochighwarning': 65535, 'soproclowwarning': 0
             }
         )
     ])
@@ -418,6 +420,8 @@ class TestCCmis(object):
                     'prefecberhighwarning_flag': False, 'prefecberlowwarning_flag': False,
                     'postfecberhighalarm_flag': False, 'postfecberlowalarm_flag': False, 
                     'postfecberhighwarning_flag': False, 'postfecberlowwarning_flag': False,
+                    'soprochighalarm_flag' : False, 'soproclowalarm_flag' : False,
+                    'soprochighwarning_flag' : False, 'soproclowwarning_flag' : False,
                 },
                 False, False, ['TuningComplete'],
                 {
@@ -433,6 +437,7 @@ class TestCCmis(object):
                     'CD low granularity, long link [ps/nm]':{1:[1000, 2000, 0, 1800, 0, False, False, False, False]},
                     'DGD [ps]':{1:[5, 30, 0, 25, 0, False, False, False, False]},
                     'SOPMD [ps^2]':{1:[5, 100, 0, 80, 0, False, False, False, False]},
+                    'SOP ROC [krad/s]':{1: [0, 65535, 0, 65535, 0, False, False, False, False]},
                     'PDL [dB]':{1:[0.5, 3, 0, 2.5, 0, False, False, False, False]},
                     'OSNR [dB]':{1:[30, 100, 26, 80, 27, False, False, False, False]},
                     'eSNR [dB]':{1:[16, 100, 13, 80, 14, False, False, False, False]},
@@ -557,7 +562,8 @@ class TestCCmis(object):
                 'rxtotpowerhighwarning_flag': False, 'rxtotpowerlowwarning_flag': False,
                 'rxsigpowerhighalarm_flag': False, 'rxsigpowerlowalarm_flag': False, 
                 'rxsigpowerhighwarning_flag': False, 'rxsigpowerlowwarning_flag': False,
-                
+                'soprochighalarm_flag' : False, 'soproclowalarm_flag' : False,
+                'soprochighwarning_flag' : False, 'soproclowwarning_flag' : False
             }
         )
     ])
@@ -571,15 +577,6 @@ class TestCCmis(object):
         self.api.get_laser_tuning_summary = MagicMock()
         self.api.get_laser_tuning_summary.return_value = mock_response[3]
         self.api.vdm_dict = mock_response[4]
-        result = self.api.get_transceiver_status()
-        assert result == expected
-
-        # For the case of 'Rx Signal Power [dBm]' not present:
-        get_transceiver_status_func.return_value = dict(mock_response[0])
-        del self.api.vdm_dict['Rx Signal Power [dBm]']
-        for k in ['rxsigpowerhighalarm_flag', 'rxsigpowerlowalarm_flag',
-                  'rxsigpowerhighwarning_flag', 'rxsigpowerlowwarning_flag']:
-            del expected[k]
         result = self.api.get_transceiver_status()
         assert result == expected
 


### PR DESCRIPTION
 Certain VDM fields not populating after encountering KeyError on 400ZR optics (#442)

* Certain VDM fields not populating after encountering KeyError on 400ZR optics



* Added soproc in the VDM_KEY_TO_DB_KEY_PREFIX_MAP and changed NA to N/A

---------

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

