### PR TITLE
Reduce firmware read timeout from 60s to 10s to prevent port breakout failure

### DIFF
--- a/sonic_platform_base/component_base.py
+++ b/sonic_platform_base/component_base.py
@@ -76,7 +76,7 @@ class ComponentBase(object):
             A string containing the component firmware update notification if required.
             By default 'None' value will be used, which indicates that no actions are required
         """
-        return None
+        return 'None'
 
     def install_firmware(self, image_path):
         """

--- a/sonic_platform_base/sonic_eeprom/eeprom_base.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_base.py
@@ -295,9 +295,21 @@ class EepromDecoder(object):
         if self.cache_name:
             F = None
             try:
+                # Ensure the directory exists
+                directory = os.path.dirname(self.cache_name)
+
+                if not os.path.exists(directory):
+                    os.makedirs(directory)
+
+                # Set directory permissions to 755
+                os.chmod(directory, 0o755)
+
                 F = open(self.cache_name, "wb")
                 F.seek(self.s)
                 F.write(e)
+
+                # Set file permissions to 755
+                os.chmod(self.cache_name, 0o755)
             except IOError as e:
                 raise IOError("Failed to write cache : %s" % (str(e)))
             finally:

--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -41,6 +41,7 @@ class SsdUtil(SsdBase):
     def __init__(self, diskdev):
         self.vendor_ssd_utility = {
             "Generic"  : { "utility" : SMARTCTL, "parser" : self.parse_generic_ssd_info },
+            "Phison"   : { "utility" : SMARTCTL, "parser" : self.parse_generic_ssd_info },
             "InnoDisk" : { "utility" : INNODISK, "parser" : self.parse_innodisk_info },
             "M.2"      : { "utility" : INNODISK, "parser" : self.parse_innodisk_info },
             "StorFly"  : { "utility" : VIRTIUM,  "parser" : self.parse_virtium_info },
@@ -83,6 +84,8 @@ class SsdUtil(SsdBase):
             return 'Virtium'
         elif self.model.startswith('SFS'):
             return 'Swissbit'
+        elif self.model.startswith(('EPM3750', 'MPT160')):
+            return 'Phison'
         else:
             return None
 

--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -47,6 +47,7 @@ class SsdUtil(SsdBase):
             "StorFly"  : { "utility" : VIRTIUM,  "parser" : self.parse_virtium_info },
             "Virtium"  : { "utility" : VIRTIUM,  "parser" : self.parse_virtium_info },
             "Swissbit" : { "utility" : SMARTCTL, "parser" : self.parse_swissbit_info },
+            "WDC"      : { "utility" : SMARTCTL, "parser" : self.parse_wdc_ssd_info }
         }
 
         self.dev = diskdev
@@ -127,6 +128,21 @@ class SsdUtil(SsdBase):
 
         self.serial = self._parse_re('Serial Number:\s*(.+?)\n', self.ssd_info)
         self.firmware = self._parse_re('Firmware Version:\s*(.+?)\n', self.ssd_info)
+
+    def parse_wdc_ssd_info(self):
+        self.model = self._parse_re('Device Model:\s*(.+?)\n', self.ssd_info)
+        self.serial = self._parse_re('Serial Number:\s*(.+?)\n', self.ssd_info)
+        self.firmware = self._parse_re('Firmware Version:\s*(.+?)\n', self.ssd_info)
+        try:
+            if ("SDASN8Y1T00" == self.model.split(' ')[3]):
+                self.nand_endurance = 400 * 1000
+                parsed_total_lbas_written = self._parse_re('Total_LBAs_Written\s*.*Offline\s*-\s*\d*', self.vendor_ssd_info)
+                total_lbas_written = int(self._parse_re('\s{7}\d*', parsed_total_lbas_written).split(' ')[7])
+                self.health = int(100.0 - (total_lbas_written * 100) / self.nand_endurance)
+                celsius_str = self._parse_re('Temperature_Celsius\s*.*', self.vendor_ssd_info)
+                self.temperature = self._parse_re('(\d*)\s\(Min.*', celsius_str)
+        except (ValueError, IndexError):
+            pass
 
     def parse_innodisk_info(self):
         if self.vendor_ssd_info:

--- a/sonic_platform_base/sonic_ssd/ssd_generic.py
+++ b/sonic_platform_base/sonic_ssd/ssd_generic.py
@@ -6,6 +6,7 @@
 #  - InnoDisk
 #  - StorFly
 #  - Virtium
+#  - WDC
 
 try:
     import re
@@ -134,8 +135,17 @@ class SsdUtil(SsdBase):
         self.serial = self._parse_re('Serial Number:\s*(.+?)\n', self.ssd_info)
         self.firmware = self._parse_re('Firmware Version:\s*(.+?)\n', self.ssd_info)
         try:
-            if ("SDASN8Y1T00" == self.model.split(' ')[3]):
+            product_number = self.model.split(' ')[3]
+            if "1T00" in product_number:
                 self.nand_endurance = 400 * 1000
+            elif "512G" in product_number:
+                self.nand_endurance = 200 * 1000
+            elif "256G" in product_number:
+                self.nand_endurance = 100 * 1000
+            else:
+                self.nand_endurance = NOT_AVAILABLE
+
+            if (self.nand_endurance != NOT_AVAILABLE):
                 parsed_total_lbas_written = self._parse_re('Total_LBAs_Written\s*.*Offline\s*-\s*\d*', self.vendor_ssd_info)
                 total_lbas_written = int(self._parse_re('\s{7}\d*', parsed_total_lbas_written).split(' ')[7])
                 self.health = int(100.0 - (total_lbas_written * 100) / self.nand_endurance)

--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -12,11 +12,73 @@ VDM_FREEZE = 128
 VDM_UNFREEZE = 0
 SYSLOG_IDENTIFIER = "CCmisApi"
 
+VDM_KEY_TO_DB_KEY_PREFIX_MAP = {
+    'Modulator Bias X/I [%]' : 'biasxi',
+    'Modulator Bias X/Q [%]' : 'biasxq',
+    'Modulator Bias X_Phase [%]' : 'biasxp',
+    'Modulator Bias Y/I [%]' : 'biasyi',
+    'Modulator Bias Y/Q [%]' : 'biasyq',
+    'Modulator Bias Y_Phase [%]' : 'biasyp',
+    'CD high granularity, short link [ps/nm]' : 'cdshort',
+    'CD low granularity, long link [ps/nm]' : 'cdlong',
+    'DGD [ps]' : 'dgd',
+    'SOPMD [ps^2]' : 'sopmd',
+    'SOP ROC [krad/s]' : 'soproc',
+    'PDL [dB]' : 'pdl',
+    'OSNR [dB]' : 'osnr',
+    'eSNR [dB]' : 'esnr',
+    'CFO [MHz]' : 'cfo',
+    'Tx Power [dBm]' : 'txcurrpower',
+    'Rx Total Power [dBm]' : 'rxtotpower',
+    'Rx Signal Power [dBm]' : 'rxsigpower'
+}
+
+VDM_SUBTYPE_IDX_MAP= {
+    1: 'highalarm',
+    2: 'lowalarm',
+    3: 'highwarning',
+    4: 'lowwarning',
+    5: 'highalarm_flag',
+    6: 'lowalarm_flag',
+    7: 'highwarning_flag',
+    8: 'lowwarning_flag'
+}
+
+
 helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 class CCmisApi(CmisApi):
     def __init__(self, xcvr_eeprom):
         super(CCmisApi, self).__init__(xcvr_eeprom)
+
+    def _update_dict_if_vdm_key_exists(self, dict_to_be_updated, new_key, vdm_dict_key, vdm_subtype_index, lane=1):
+        '''
+        This function updates the dictionary with the VDM value if the vdm_dict_key exists.
+        @param dict_to_be_updated: the dictionary to be updated.
+        @param new_key: the key to be added in dict_to_be_updated.
+        @param vdm_dict_key: lookup key in the VDM dictionary.
+        @param vdm_subtype_index: the index of the VDM subtype in the VDM page.
+            0 refers to the real time value
+            1 refers to the high alarm threshold
+            2 refers to the low alarm threshold
+            3 refers to the high warning threshold
+            4 refers to the low warning threshold
+            5 refers to the high alarm flag
+            6 refers to the low alarm flag
+            7 refers to the high warning flag
+            8 refers to the low warning flag
+        @param lane: the lane number. Default is 1.
+
+        @return: True if the key exists in the VDM dictionary, False if not.
+        '''
+        try:
+            dict_to_be_updated[new_key] = self.vdm_dict[vdm_dict_key][lane][vdm_subtype_index]
+        except KeyError:
+            dict_to_be_updated[new_key] = 'N/A'
+            helper_logger.log_debug('key {} not present in VDM'.format(new_key))
+            return False
+
+        return True
 
     def get_freq_grid(self):
         '''
@@ -377,27 +439,10 @@ class CCmisApi(CmisApi):
         ========================================================================
         """
         trans_dom = super(CCmisApi,self).get_transceiver_bulk_status()
-        try:
-            trans_dom['bias_xi'] = self.vdm_dict['Modulator Bias X/I [%]'][1][0]
-            trans_dom['bias_xq'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][0]
-            trans_dom['bias_xp'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][0]
-            trans_dom['bias_yi'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][0]
-            trans_dom['bias_yq'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][0]
-            trans_dom['bias_yp'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][0]
-            trans_dom['cd_shortlink'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][0]
-            trans_dom['cd_longlink'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][0]
-            trans_dom['dgd'] = self.vdm_dict['DGD [ps]'][1][0]
-            trans_dom['sopmd'] = self.vdm_dict['SOPMD [ps^2]'][1][0]
-            trans_dom['soproc'] = self.vdm_dict['SOP ROC [krad/s]'][1][0]
-            trans_dom['pdl'] = self.vdm_dict['PDL [dB]'][1][0]
-            trans_dom['osnr'] = self.vdm_dict['OSNR [dB]'][1][0]
-            trans_dom['esnr'] = self.vdm_dict['eSNR [dB]'][1][0]
-            trans_dom['cfo'] = self.vdm_dict['CFO [MHz]'][1][0]
-            trans_dom['tx_curr_power'] = self.vdm_dict['Tx Power [dBm]'][1][0]
-            trans_dom['rx_tot_power'] = self.vdm_dict['Rx Total Power [dBm]'][1][0]
-            trans_dom['rx_sig_power'] = self.vdm_dict['Rx Signal Power [dBm]'][1][0]
-        except KeyError:
-            pass
+
+        for vdm_key, trans_dom_key in VDM_KEY_TO_DB_KEY_PREFIX_MAP.items():
+            self._update_dict_if_vdm_key_exists(trans_dom, trans_dom_key, vdm_key, 0)
+
         trans_dom['laser_config_freq'] = self.get_laser_config_freq()
         trans_dom['laser_curr_freq'] = self.get_current_laser_freq()
         trans_dom['tx_config_power'] = self.get_tx_config_power()
@@ -515,77 +560,12 @@ class CCmisApi(CmisApi):
         ========================================================================
         """
         trans_dom_th = super(CCmisApi,self).get_transceiver_threshold_info()
-        try:
-            trans_dom_th['biasxihighalarm'] = self.vdm_dict['Modulator Bias X/I [%]'][1][1]
-            trans_dom_th['biasxilowalarm'] = self.vdm_dict['Modulator Bias X/I [%]'][1][2]
-            trans_dom_th['biasxihighwarning'] = self.vdm_dict['Modulator Bias X/I [%]'][1][3]
-            trans_dom_th['biasxilowwarning'] = self.vdm_dict['Modulator Bias X/I [%]'][1][4]
-            trans_dom_th['biasxqhighalarm'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][1]
-            trans_dom_th['biasxqlowalarm'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][2]
-            trans_dom_th['biasxqhighwarning'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][3]
-            trans_dom_th['biasxqlowwarning'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][4]
-            trans_dom_th['biasxphighalarm'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][1]
-            trans_dom_th['biasxplowalarm'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][2]
-            trans_dom_th['biasxphighwarning'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][3]
-            trans_dom_th['biasxplowwarning'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][4]
-            trans_dom_th['biasyihighalarm'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][1]
-            trans_dom_th['biasyilowalarm'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][2]
-            trans_dom_th['biasyihighwarning'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][3]
-            trans_dom_th['biasyilowwarning'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][4]
-            trans_dom_th['biasyqhighalarm'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][1]
-            trans_dom_th['biasyqlowalarm'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][2]
-            trans_dom_th['biasyqhighwarning'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][3]
-            trans_dom_th['biasyqlowwarning'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][4]
-            trans_dom_th['biasyphighalarm'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][1]
-            trans_dom_th['biasyplowalarm'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][2]
-            trans_dom_th['biasyphighwarning'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][3]
-            trans_dom_th['biasyplowwarning'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][4]
-            trans_dom_th['cdshorthighalarm'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][1]
-            trans_dom_th['cdshortlowalarm'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][2]
-            trans_dom_th['cdshorthighwarning'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][3]
-            trans_dom_th['cdshortlowwarning'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][4]
-            trans_dom_th['cdlonghighalarm'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][1]
-            trans_dom_th['cdlonglowalarm'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][2]
-            trans_dom_th['cdlonghighwarning'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][3]
-            trans_dom_th['cdlonglowwarning'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][4]
-            trans_dom_th['dgdhighalarm'] = self.vdm_dict['DGD [ps]'][1][1]
-            trans_dom_th['dgdlowalarm'] = self.vdm_dict['DGD [ps]'][1][2]
-            trans_dom_th['dgdhighwarning'] = self.vdm_dict['DGD [ps]'][1][3]
-            trans_dom_th['dgdlowwarning'] = self.vdm_dict['DGD [ps]'][1][4]
-            trans_dom_th['sopmdhighalarm'] = self.vdm_dict['SOPMD [ps^2]'][1][1]
-            trans_dom_th['sopmdlowalarm'] = self.vdm_dict['SOPMD [ps^2]'][1][2]
-            trans_dom_th['sopmdhighwarning'] = self.vdm_dict['SOPMD [ps^2]'][1][3]
-            trans_dom_th['sopmdlowwarning'] = self.vdm_dict['SOPMD [ps^2]'][1][4]
-            trans_dom_th['pdlhighalarm'] = self.vdm_dict['PDL [dB]'][1][1]
-            trans_dom_th['pdllowalarm'] = self.vdm_dict['PDL [dB]'][1][2]
-            trans_dom_th['pdlhighwarning'] = self.vdm_dict['PDL [dB]'][1][3]
-            trans_dom_th['pdllowwarning'] = self.vdm_dict['PDL [dB]'][1][4]
-            trans_dom_th['osnrhighalarm'] = self.vdm_dict['OSNR [dB]'][1][1]
-            trans_dom_th['osnrlowalarm'] = self.vdm_dict['OSNR [dB]'][1][2]
-            trans_dom_th['osnrhighwarning'] = self.vdm_dict['OSNR [dB]'][1][3]
-            trans_dom_th['osnrlowwarning'] = self.vdm_dict['OSNR [dB]'][1][4]
-            trans_dom_th['esnrhighalarm'] = self.vdm_dict['eSNR [dB]'][1][1]
-            trans_dom_th['esnrlowalarm'] = self.vdm_dict['eSNR [dB]'][1][2]
-            trans_dom_th['esnrhighwarning'] = self.vdm_dict['eSNR [dB]'][1][3]
-            trans_dom_th['esnrlowwarning'] = self.vdm_dict['eSNR [dB]'][1][4]
-            trans_dom_th['cfohighalarm'] = self.vdm_dict['CFO [MHz]'][1][1]
-            trans_dom_th['cfolowalarm'] = self.vdm_dict['CFO [MHz]'][1][2]
-            trans_dom_th['cfohighwarning'] = self.vdm_dict['CFO [MHz]'][1][3]
-            trans_dom_th['cfolowwarning'] = self.vdm_dict['CFO [MHz]'][1][4]
-            trans_dom_th['txcurrpowerhighalarm'] = self.vdm_dict['Tx Power [dBm]'][1][1]
-            trans_dom_th['txcurrpowerlowalarm'] = self.vdm_dict['Tx Power [dBm]'][1][2]
-            trans_dom_th['txcurrpowerhighwarning'] = self.vdm_dict['Tx Power [dBm]'][1][3]
-            trans_dom_th['txcurrpowerlowwarning'] = self.vdm_dict['Tx Power [dBm]'][1][4]
-            trans_dom_th['rxtotpowerhighalarm'] = self.vdm_dict['Rx Total Power [dBm]'][1][1]
-            trans_dom_th['rxtotpowerlowalarm'] = self.vdm_dict['Rx Total Power [dBm]'][1][2]
-            trans_dom_th['rxtotpowerhighwarning'] = self.vdm_dict['Rx Total Power [dBm]'][1][3]
-            trans_dom_th['rxtotpowerlowwarning'] = self.vdm_dict['Rx Total Power [dBm]'][1][4]
-            trans_dom_th['rxsigpowerhighalarm'] = self.vdm_dict['Rx Signal Power [dBm]'][1][1]
-            trans_dom_th['rxsigpowerlowalarm'] = self.vdm_dict['Rx Signal Power [dBm]'][1][2]
-            trans_dom_th['rxsigpowerhighwarning'] = self.vdm_dict['Rx Signal Power [dBm]'][1][3]
-            trans_dom_th['rxsigpowerlowwarning'] = self.vdm_dict['Rx Signal Power [dBm]'][1][4]
-        except KeyError:
-            pass
+
+        for vdm_key, trans_dom_th_key_prefix in VDM_KEY_TO_DB_KEY_PREFIX_MAP.items():
+            for i in range(1, 5):
+                trans_dom_th_key = trans_dom_th_key_prefix + VDM_SUBTYPE_IDX_MAP[i]
+                self._update_dict_if_vdm_key_exists(trans_dom_th, trans_dom_th_key, vdm_key, i)
+
         return trans_dom_th
 
     def get_transceiver_status(self):
@@ -772,77 +752,12 @@ class CCmisApi(CmisApi):
         trans_status['tuning_not_accepted'] = 'TuningNotAccepted' in laser_tuning_summary
         trans_status['invalid_channel_num'] = 'InvalidChannel' in laser_tuning_summary
         trans_status['tuning_complete'] = 'TuningComplete' in laser_tuning_summary
-        try:
-            trans_status['biasxihighalarm_flag'] = self.vdm_dict['Modulator Bias X/I [%]'][1][5]
-            trans_status['biasxilowalarm_flag'] = self.vdm_dict['Modulator Bias X/I [%]'][1][6]
-            trans_status['biasxihighwarning_flag'] = self.vdm_dict['Modulator Bias X/I [%]'][1][7]
-            trans_status['biasxilowwarning_flag'] = self.vdm_dict['Modulator Bias X/I [%]'][1][8]
-            trans_status['biasxqhighalarm_flag'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][5]
-            trans_status['biasxqlowalarm_flag'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][6]
-            trans_status['biasxqhighwarning_flag'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][7]
-            trans_status['biasxqlowwarning_flag'] = self.vdm_dict['Modulator Bias X/Q [%]'][1][8]
-            trans_status['biasxphighalarm_flag'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][5]
-            trans_status['biasxplowalarm_flag'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][6]
-            trans_status['biasxphighwarning_flag'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][7]
-            trans_status['biasxplowwarning_flag'] = self.vdm_dict['Modulator Bias X_Phase [%]'][1][8]
-            trans_status['biasyihighalarm_flag'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][5]
-            trans_status['biasyilowalarm_flag'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][6]
-            trans_status['biasyihighwarning_flag'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][7]
-            trans_status['biasyilowwarning_flag'] = self.vdm_dict['Modulator Bias Y/I [%]'][1][8]
-            trans_status['biasyqhighalarm_flag'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][5]
-            trans_status['biasyqlowalarm_flag'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][6]
-            trans_status['biasyqhighwarning_flag'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][7]
-            trans_status['biasyqlowwarning_flag'] = self.vdm_dict['Modulator Bias Y/Q [%]'][1][8]
-            trans_status['biasyphighalarm_flag'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][5]
-            trans_status['biasyplowalarm_flag'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][6]
-            trans_status['biasyphighwarning_flag'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][7]
-            trans_status['biasyplowwarning_flag'] = self.vdm_dict['Modulator Bias Y_Phase [%]'][1][8]
-            trans_status['cdshorthighalarm_flag'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][5]
-            trans_status['cdshortlowalarm_flag'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][6]
-            trans_status['cdshorthighwarning_flag'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][7]
-            trans_status['cdshortlowwarning_flag'] = self.vdm_dict['CD high granularity, short link [ps/nm]'][1][8]
-            trans_status['cdlonghighalarm_flag'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][5]
-            trans_status['cdlonglowalarm_flag'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][6]
-            trans_status['cdlonghighwarning_flag'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][7]
-            trans_status['cdlonglowwarning_flag'] = self.vdm_dict['CD low granularity, long link [ps/nm]'][1][8]
-            trans_status['dgdhighalarm_flag'] = self.vdm_dict['DGD [ps]'][1][5]
-            trans_status['dgdlowalarm_flag'] = self.vdm_dict['DGD [ps]'][1][6]
-            trans_status['dgdhighwarning_flag'] = self.vdm_dict['DGD [ps]'][1][7]
-            trans_status['dgdlowwarning_flag'] = self.vdm_dict['DGD [ps]'][1][8]
-            trans_status['sopmdhighalarm_flag'] = self.vdm_dict['SOPMD [ps^2]'][1][5]
-            trans_status['sopmdlowalarm_flag'] = self.vdm_dict['SOPMD [ps^2]'][1][6]
-            trans_status['sopmdhighwarning_flag'] = self.vdm_dict['SOPMD [ps^2]'][1][7]
-            trans_status['sopmdlowwarning_flag'] = self.vdm_dict['SOPMD [ps^2]'][1][8]
-            trans_status['pdlhighalarm_flag'] = self.vdm_dict['PDL [dB]'][1][5]
-            trans_status['pdllowalarm_flag'] = self.vdm_dict['PDL [dB]'][1][6]
-            trans_status['pdlhighwarning_flag'] = self.vdm_dict['PDL [dB]'][1][7]
-            trans_status['pdllowwarning_flag'] = self.vdm_dict['PDL [dB]'][1][8]
-            trans_status['osnrhighalarm_flag'] = self.vdm_dict['OSNR [dB]'][1][5]
-            trans_status['osnrlowalarm_flag'] = self.vdm_dict['OSNR [dB]'][1][6]
-            trans_status['osnrhighwarning_flag'] = self.vdm_dict['OSNR [dB]'][1][7]
-            trans_status['osnrlowwarning_flag'] = self.vdm_dict['OSNR [dB]'][1][8]
-            trans_status['esnrhighalarm_flag'] = self.vdm_dict['eSNR [dB]'][1][5]
-            trans_status['esnrlowalarm_flag'] = self.vdm_dict['eSNR [dB]'][1][6]
-            trans_status['esnrhighwarning_flag'] = self.vdm_dict['eSNR [dB]'][1][7]
-            trans_status['esnrlowwarning_flag'] = self.vdm_dict['eSNR [dB]'][1][8]
-            trans_status['cfohighalarm_flag'] = self.vdm_dict['CFO [MHz]'][1][5]
-            trans_status['cfolowalarm_flag'] = self.vdm_dict['CFO [MHz]'][1][6]
-            trans_status['cfohighwarning_flag'] = self.vdm_dict['CFO [MHz]'][1][7]
-            trans_status['cfolowwarning_flag'] = self.vdm_dict['CFO [MHz]'][1][8]
-            trans_status['txcurrpowerhighalarm_flag'] = self.vdm_dict['Tx Power [dBm]'][1][5]
-            trans_status['txcurrpowerlowalarm_flag'] = self.vdm_dict['Tx Power [dBm]'][1][6]
-            trans_status['txcurrpowerhighwarning_flag'] = self.vdm_dict['Tx Power [dBm]'][1][7]
-            trans_status['txcurrpowerlowwarning_flag'] = self.vdm_dict['Tx Power [dBm]'][1][8]
-            trans_status['rxtotpowerhighalarm_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][5]
-            trans_status['rxtotpowerlowalarm_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][6]
-            trans_status['rxtotpowerhighwarning_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][7]
-            trans_status['rxtotpowerlowwarning_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][8]
-            trans_status['rxsigpowerhighalarm_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][5]
-            trans_status['rxsigpowerlowalarm_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][6]
-            trans_status['rxsigpowerhighwarning_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][7]
-            trans_status['rxsigpowerlowwarning_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][8]
-        except KeyError:
-            helper_logger.log_debug('fields not present in VDM')
+
+        for vdm_key, trans_status_key_prefix in VDM_KEY_TO_DB_KEY_PREFIX_MAP.items():
+            for i in range(5, 9):
+                trans_status_key = trans_status_key_prefix + VDM_SUBTYPE_IDX_MAP[i]
+                self._update_dict_if_vdm_key_exists(trans_status, trans_status_key, vdm_key, i)
+
         return trans_status
 
     def get_transceiver_pm(self):

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -181,8 +181,6 @@ class CmisApi(XcvrApi):
         xcvr_info['cmis_rev'] = self.get_cmis_rev()
         xcvr_info['specification_compliance'] = self.get_module_media_type()
 
-        xcvr_info['active_firmware'], xcvr_info['inactive_firmware'] = self.get_transceiver_info_firmware_versions()
-
         # In normal case will get a valid value for each of the fields. If get a 'None' value
         # means there was a failure while reading the EEPROM, either because the EEPROM was
         # not ready yet or experincing some other issues. It shouldn't return a dict with a
@@ -194,15 +192,18 @@ class CmisApi(XcvrApi):
             return xcvr_info
 
     def get_transceiver_info_firmware_versions(self):
+        return_dict = {"active_firmware" : "N/A", "inactive_firmware" : "N/A"}
         result = self.get_module_fw_info()
         if result is None:
-            return ["N/A", "N/A"]
+            return return_dict
         try:
             ( _, _, _, _, _, _, _, _, ActiveFirmware, InactiveFirmware) = result['result']
         except (ValueError, TypeError):
-            return ["N/A", "N/A"]
-
-        return [ActiveFirmware, InactiveFirmware]
+            return return_dict
+        
+        return_dict["active_firmware"] = ActiveFirmware
+        return_dict["inactive_firmware"] = InactiveFirmware
+        return return_dict
 
     def get_transceiver_bulk_status(self):
         temp = self.get_module_temperature()

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -43,6 +43,18 @@ class CmisApi(XcvrApi):
         '''
         return self.xcvr_eeprom.read(consts.VENDOR_PART_NO_FIELD)
 
+    def get_cable_length_type(self):
+        '''
+        This function returns the cable type of the module
+        '''
+        return "Length Cable Assembly(m)"
+
+    def get_cable_length(self):
+        '''
+        This function returns the cable length of the module
+        '''
+        return self.xcvr_eeprom.read(consts.LENGTH_ASSEMBLY_FIELD)
+
     def get_vendor_rev(self):
         '''
         This function returns the revision level for part number provided by vendor
@@ -146,7 +158,6 @@ class CmisApi(XcvrApi):
             "encoding": "N/A", # Not supported
             "ext_identifier": "%s (%sW Max)" % (power_class, max_power),
             "ext_rateselect_compliance": "N/A", # Not supported
-            "cable_type": "Length Cable Assembly(m)",
             "cable_length": float(admin_info[consts.LENGTH_ASSEMBLY_FIELD]),
             "nominal_bit_rate": 0, # Not supported
             "vendor_date": admin_info[consts.VENDOR_DATE_FIELD],
@@ -160,6 +171,7 @@ class CmisApi(XcvrApi):
         xcvr_info['media_lane_count'] = self.get_media_lane_count()
         xcvr_info['host_lane_assignment_option'] = self.get_host_lane_assignment_option()
         xcvr_info['media_lane_assignment_option'] = self.get_media_lane_assignment_option()
+        xcvr_info['cable_type'] = self.get_cable_length_type()
         apsel_dict = self.get_active_apsel_hostlane()
         for lane in range(1, self.NUM_CHANNELS+1):
             xcvr_info["%s%d" % ("active_apsel_hostlane", lane)] = \

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -703,6 +703,18 @@ class CmisApi(XcvrApi):
         else:
             return 'Unknown media interface'
 
+    def is_copper(self):
+        '''
+        Returns True if xcvr is copper, False if xcvr is optical
+        '''
+        media_type = self.get_module_media_type()
+        if media_type == 'passive_copper_media_interface' or media_type == 'base_t_media_interface':
+            return True
+        elif  media_type == 'nm_850_media_interface' or media_type == 'sm_media_interface' or media_type == 'active_cable_media_interface':
+            return False
+        else:
+            return None
+
     def is_coherent_module(self):
         '''
         Returns True if the module follow C-CMIS spec, False otherwise

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -2037,34 +2037,34 @@ class CmisApi(XcvrApi):
             key = "{}_{}".format(consts.HOST_ELECTRICAL_INTERFACE, app)
             val = dic.get(key)
             if val in [None, 'Unknown', 'Undefined']:
-                break
+                continue
             buf['host_electrical_interface_id'] = val
 
             prefix = map.get(self.xcvr_eeprom.read(consts.MEDIA_TYPE_FIELD))
             if prefix is None:
-                break
+                continue
             key = "{}_{}".format(prefix, app)
             val = dic.get(key)
             if val in [None, 'Unknown']:
-                break
+                continue
             buf['module_media_interface_id'] = val
 
             key = "{}_{}".format(consts.MEDIA_LANE_COUNT, app)
             val = dic.get(key)
             if val is None:
-                break
+                continue
             buf['media_lane_count'] = val
 
             key = "{}_{}".format(consts.HOST_LANE_COUNT, app)
             val = dic.get(key)
             if val is None:
-                break
+                continue
             buf['host_lane_count'] = val
 
             key = "{}_{}".format(consts.HOST_LANE_ASSIGNMENT_OPTION, app)
             val = dic.get(key)
             if val is None:
-                break
+                continue
             buf['host_lane_assignment_options'] = val
 
             key = "{}_{}".format(consts.MEDIA_LANE_ASSIGNMENT_OPTION, app)

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -1056,7 +1056,11 @@ class CmisApi(XcvrApi):
                 # Force module transition to LowPwr under SW control
                 lpmode_val = lpmode_val | (1 << CmisApi.LowPwrRequestSW)
                 self.xcvr_eeprom.write(consts.MODULE_LEVEL_CONTROL, lpmode_val)
-                time.sleep(0.1)
+                for retries in range(50):
+                    if self.get_lpmode():
+                        break
+                    time.sleep(0.1)
+            
                 return self.get_lpmode()
             else:
                 # Force transition from LowPwr to HighPower state under SW control.
@@ -1066,7 +1070,8 @@ class CmisApi(XcvrApi):
                 self.xcvr_eeprom.write(consts.MODULE_LEVEL_CONTROL, lpmode_val)
                 time.sleep(1)
                 mstate = self.get_module_state()
-                return True if mstate == 'ModuleReady' else False
+                return True if mstate == 'ModuleReady' or mstate=='ModulePwrUp' else False
+
         return False
 
     def get_loopback_capability(self):

--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -707,6 +707,9 @@ class CmisApi(XcvrApi):
         '''
         Returns True if xcvr is copper, False if xcvr is optical
         '''
+        media_tech = self.get_media_interface_technology()
+        if media_tech and 'Copper cable' in media_tech:
+            return True
         media_type = self.get_module_media_type()
         if media_type == 'passive_copper_media_interface' or media_type == 'base_t_media_interface':
             return True

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -15,7 +15,7 @@ class XcvrApi(object):
             return float("-inf")
         elif mW < 0:
             return float("NaN")
-        return 10. * log10(mW)
+        return round(10. * log10(mW), 3)
 
     def get_model(self):
         """

--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -183,6 +183,7 @@ class Sff8024(XcvrCodes):
         5: 'base_t_media_interface'
     }
 
+    # Host Electrical Interface IDs
     HOST_ELECTRICAL_INTERFACE = {
         0: 'Undefined',
         1: '1000BASE -CX(Clause 39)',
@@ -250,14 +251,26 @@ class Sff8024(XcvrCodes):
         64: 'FOIC4.8 (ITU-T G.709.1 G.Sup58)',
         65: 'CAUI-4 C2M (Annex 83E) without FEC',
         66: 'CAUI-4 C2M (Annex 83E) with RS(528,514) FEC',
+        67: '50GBASE-CR2 (Ethernet Technology Consortium) with RS(528,514) (Clause 91) FEC',
+        68: '50GBASE-CR2 (Ethernet Technology Consortium) with BASE-R (Clause 74), Fire code FEC',
+        69: '50GBASE-CR2 (Ethernet Technology Consortium) with no FEC',
+        70: '100GBASE-CR1 (Clause 162)',
+        71: '200GBASE-CR2 (Clause 162)',
+        72: '400GBASE-CR4 (Clause 162)',
+        73: '800G-ETC-CR8',
+        74: '128GFC (FC-PI-8)',
         75: '100GAUI-1-S C2M (Annex 120G)',
         76: '100GAUI-1-L C2M (Annex 120G)',
+        77: '200GAUI-2-S C2M (Annex 120G)',
+        78: '200GAUI-2-L C2M (Annex 120G)',
         79: '400GAUI-4-S C2M (Annex 120G)',
         80: '400GAUI-4-L C2M (Annex 120G)',
         81: '800G S C2M (placeholder)',
-        82: '800G L C2M (placeholder)'
+        82: '800G L C2M (placeholder)',
+        83: 'OTL4.2'
     }
 
+    # MMF media interface IDs
     NM_850_MEDIA_INTERFACE = {
         0: 'Undefined',
         1: '10GBASE-SW (Clause 52)',
@@ -278,16 +291,23 @@ class Sff8024(XcvrCodes):
         16: '400GBASE-SR8 (Clause 138)',
         17: '400G-SR4 (Placeholder)',
         18: '800G-SR8 (Placeholder)',
-        26: '400GBASE-SR4.2 (Clause 150) (400GE BiDi)',
         19: '8GFC-MM (FC-PI-4)',
         20: '10GFC-MM (10GFC)',
         21: '16GFC-MM (FC-PI-5)',
         22: '32GFC-MM (FC-PI-6)',
         23: '64GFC-MM (FC-PI 7)',
         24: '128GFC-MM4 (FC-PI-6P)',
-        25: '256GFC-MM4 (FC-PI-7P)'
+        25: '256GFC-MM4 (FC-PI-7P)',
+        26: '400GBASE-SR4.2 (Clause 150) (400GE BiDi)',
+        27: '200G-SR2 (Clause 167)',
+        28: '128GFC-MM (FC-PI-8)',
+        29: '100G-VR1 (Clause 167)',
+        30: '200G-VR2 (Clause 167)',
+        31: '400G-VR4 (Clause 167)',
+        32: '800G-VR8 (Placeholder)'
     }
 
+    # SMF media interface IDs
     SM_MEDIA_INTERFACE = {
         0: 'Undefined',
         1: '10GBASE-LW (Cl 52)',
@@ -326,9 +346,7 @@ class Sff8024(XcvrCodes):
         34: '32GFC-SM (FC-PI-6)',
         35: '64GFC-SM (FC-PI-7)',
         36: '128GFC-PSM4 (FC-PI-6P)',
-        37: '256GFC-PSM4 (FC-PI-7P)',
         38: '128GFC-CWDM4 (FC-PI-6P)',
-        39: '256GFC-CWDM4 (FC-PI-7P)',
         44: '4I1-9D1F (G.959.1)',
         45: '4L1-9C1F (G.959.1)',
         46: '4L1-9D1F (G.959.1)',
@@ -337,6 +355,7 @@ class Sff8024(XcvrCodes):
         49: '4I1-4D1F (G.959.1)',
         50: '8R1-4D1F (G.959.1)',
         51: '8I1-4D1F (G.959.1)',
+        52: '100G CWDM4-OCP',
         56: '10G-SR',
         57: '10G-LR',
         58: '25G-SR',
@@ -345,18 +364,40 @@ class Sff8024(XcvrCodes):
         61: '25G-LR-BiDi',
         62: '400ZR, DWDM, amplified',
         63: '400ZR, Single Wavelength, Unamplified',
+        64: '50GBASE-ER (Cl 139)',
+        65: '200GBASE-ER4 (Cl 122)',
+        66: '400GBASE-ER8 (Cl 122)',
+        67: '400GBASE-LR4-6 (Cl 151)',
+        68: '100GBASE-ZR (Cl 154)',
+        69: '128GFC-SM (FC-PI-8)',
         70: 'ZR400-OFEC-16QAM',
         71: 'ZR300-OFEC-8QAM',
         72: 'ZR200-OFEC-QPSK',
-        73: 'ZR100-OFEC-QPSK'
+        73: 'ZR100-OFEC-QPSK',
+        74: '100G-LR1-20',
+        75: '100G-ER1-30',
+        76: '100G-ER1-40',
+        77: '400GBASE-ZR (Cl 156)',
+        78: '10GBASE-BR (Cl 158)',
+        79: '25GBASE-BR (Cl 159)',
+        80: '50GBASE-BR (Cl 160)',
+        81: 'FOIC1.4-DO (G.709.3/Y.1331.3)',
+        82: 'FOIC2.8-DO (G.709.3/Y.1331.3)',
+        83: 'FOIC4.8-DO (G.709.3/Y.1331.3)',
+        84: 'FOIC2.4-DO (G.709.3/Y.1331.3)',
+        85: '400GBASE-DR4-2 (placeholder)',
+        86: '800GBASE-DR8 (placeholder)',
+        87: '800GBASE-DR8-2 (placeholder)'
     }
 
+    # Passive and Linear Active Copper Cable and Passive Loopback media interface codes
     PASSIVE_COPPER_MEDIA_INTERFACE = {
         0: 'Undefined',
         1: 'Copper cable',
-        2: 'Passive Loopback module'
+        191: 'Passive Loopback module'
     }
 
+    # Limiting and Retimed Active Cable assembly and Active Loopback media interface codes
     ACTIVE_CABLE_MEDIA_INTERFACE = {
         0: 'Undefined',
         1: 'Active Cable assembly with BER < 10^-12',
@@ -366,12 +407,16 @@ class Sff8024(XcvrCodes):
         191: 'Active Loopback module'
     }
 
+    # BASE-T media interface codes
     BASE_T_MEDIA_INTERFACE = {
         0: 'Undefined',
         1: '1000BASE-T (Clause 40)',
         2: '2.5GBASE-T (Clause 126)',
         3: '5GBASE-T (Clause 126)',
-        4: '10GBASE-T (Clause 55)'
+        4: '10GBASE-T (Clause 55)',
+        5: '25GBASE-T (Clause 113)',
+        6: '40GBASE-T (Clause 113)',
+        7: '50GBASE-T (Placeholder)'
     }
 
     # TODO: Add other codes

--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8636.py
@@ -60,6 +60,7 @@ class Sff8636Codes(Sff8024):
         32: "10GBASE-LR",
         64: "10GBASE-LRM",
         128: "Extended",
+        136: "40GBASE-CR4,Extended"
     }
 
     SONET_COMPLIANCE = {

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
@@ -50,7 +50,9 @@ class Sff8636MemMap(XcvrMemMap):
             ),
             CodeRegField(consts.CONNECTOR_FIELD, self.get_addr(0, 130), self.codes.CONNECTORS),
             RegGroupField(consts.SPEC_COMPLIANCE_FIELD, 
-                CodeRegField(consts.ETHERNET_10_40G_COMPLIANCE_FIELD, self.get_addr(0, 131), self.codes.ETHERNET_10_40G_COMPLIANCE),
+                CodeRegField(consts.ETHERNET_10_40G_COMPLIANCE_FIELD, self.get_addr(0, 131), self.codes.ETHERNET_10_40G_COMPLIANCE,
+                    *(RegBitField("%s_%d" % (consts.ETHERNET_10_40G_COMPLIANCE_FIELD, bit), bit) for bit in range(0, 7))
+                ),
                 CodeRegField(consts.SONET_COMPLIANCE_FIELD, self.get_addr(0, 132), self.codes.SONET_COMPLIANCE),
                 CodeRegField(consts.SAS_SATA_COMPLIANCE_FIELD, self.get_addr(0, 133), self.codes.SAS_SATA_COMPLIANCE),
                 CodeRegField(consts.GIGABIT_ETHERNET_COMPLIANCE_FIELD, self.get_addr(0, 134), self.codes.GIGABIT_ETHERNET_COMPLIANCE),

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/sff8636.py
@@ -50,9 +50,7 @@ class Sff8636MemMap(XcvrMemMap):
             ),
             CodeRegField(consts.CONNECTOR_FIELD, self.get_addr(0, 130), self.codes.CONNECTORS),
             RegGroupField(consts.SPEC_COMPLIANCE_FIELD, 
-                CodeRegField(consts.ETHERNET_10_40G_COMPLIANCE_FIELD, self.get_addr(0, 131), self.codes.ETHERNET_10_40G_COMPLIANCE,
-                    *(RegBitField("%s_%d" % (consts.ETHERNET_10_40G_COMPLIANCE_FIELD, bit), bit) for bit in range(0, 7))
-                ),
+                CodeRegField(consts.ETHERNET_10_40G_COMPLIANCE_FIELD, self.get_addr(0, 131), self.codes.ETHERNET_10_40G_COMPLIANCE),
                 CodeRegField(consts.SONET_COMPLIANCE_FIELD, self.get_addr(0, 132), self.codes.SONET_COMPLIANCE),
                 CodeRegField(consts.SAS_SATA_COMPLIANCE_FIELD, self.get_addr(0, 133), self.codes.SAS_SATA_COMPLIANCE),
                 CodeRegField(consts.GIGABIT_ETHERNET_COMPLIANCE_FIELD, self.get_addr(0, 134), self.codes.GIGABIT_ETHERNET_COMPLIANCE),

--- a/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
+++ b/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py
@@ -230,6 +230,15 @@ class SfpOptoeBase(SfpBase):
         except (OSError, IOError):
             pass
 
+    def set_optoe_write_timeout(self, write_timeout):
+        sys_path = self.get_eeprom_path()
+        sys_path = sys_path.replace("eeprom", "write_timeout")
+        try:
+            with open(sys_path, mode='w') as f:
+                f.write(str(write_timeout))
+        except (OSError, IOError):
+            pass
+
     def read_eeprom(self, offset, num_bytes):
         try:
             with open(self.get_eeprom_path(), mode='rb', buffering=0) as f:

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -97,7 +97,7 @@ class XcvrApiFactory(object):
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
             api = Sff8636Api(xcvr_eeprom)
         # QSFP+ or QSFP
-        elif id == 0x0D or id == 0x0C:
+        elif id == 0x0d:
             revision_compliance = self._get_revision_compliance()
             if revision_compliance >= 3:
                 codes = Sff8636Codes
@@ -109,6 +109,11 @@ class XcvrApiFactory(object):
                 mem_map = Sff8436MemMap(codes)
                 xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
                 api = Sff8436Api(xcvr_eeprom)
+        elif id == 0x0c:
+            codes = Sff8436Codes
+            mem_map = Sff8436MemMap(codes)
+            xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
+            api = Sff8436Api(xcvr_eeprom)
         elif id == 0x03:
             codes = Sff8472Codes
             mem_map = Sff8472MemMap(codes)

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -34,6 +34,8 @@ VENDOR_PART_NUM_OFFSET = 148
 VENDOR_NAME_LENGTH = 16
 VENDOR_PART_NUM_LENGTH = 16
 
+CREDO_800G_AEC_VENDOR_PN_LIST = ["CAC81X321M2MC1MS", "CAC815321M2MC1MS", "CAC82X321M2MC1MS"]
+
 class XcvrApiFactory(object):
     def __init__(self, reader, writer):
         self.reader = reader
@@ -72,7 +74,7 @@ class XcvrApiFactory(object):
         if id == 0x18 or id == 0x19 or id == 0x1e:
             vendor_name = self._get_vendor_name()
             vendor_pn = self._get_vendor_part_num()
-            if vendor_name == 'Credo' and vendor_pn == 'CAC81X321M2MC1MS':
+            if vendor_name == 'Credo' and vendor_pn in CREDO_800G_AEC_VENDOR_PN_LIST:
                 codes = CmisAec800gCodes
                 mem_map = CmisAec800gMemMap(CmisAec800gCodes)
                 xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -96,8 +96,8 @@ class XcvrApiFactory(object):
             mem_map = Sff8636MemMap(codes)
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
             api = Sff8636Api(xcvr_eeprom)
-        # QSFP+
-        elif id == 0x0D:
+        # QSFP+ or QSFP
+        elif id == 0x0D or id == 0x0C:
             revision_compliance = self._get_revision_compliance()
             if revision_compliance >= 3:
                 codes = Sff8636Codes

--- a/tests/component_base_test.py
+++ b/tests/component_base_test.py
@@ -1,0 +1,7 @@
+from sonic_platform_base.component_base import ComponentBase
+
+class TestComponentBase:
+
+    def test_get_firmware_update_notification(self):
+        cpnt = ComponentBase()
+        assert(cpnt.get_firmware_update_notification(None) == "None")

--- a/tests/sonic_xcvr/test_ccmis.py
+++ b/tests/sonic_xcvr/test_ccmis.py
@@ -233,14 +233,14 @@ class TestCCmis(object):
                 'laser_temperature': 40,
                 'prefec_ber': 0.001,
                 'postfec_ber': 0,
-                'bias_xi': 50,
-                'bias_xq': 50,
-                'bias_xp': 50,
-                'bias_yi': 50,
-                'bias_yq': 50,
-                'bias_yp': 50,
-                'cd_shortlink': 1000,
-                'cd_longlink': 1000,
+                'biasxi': 50,
+                'biasxq': 50,
+                'biasxp': 50,
+                'biasyi': 50,
+                'biasyq': 50,
+                'biasyp': 50,
+                'cdshort': 1000,
+                'cdlong': 1000,
                 'dgd': 5,
                 'sopmd': 5,
                 'soproc': 0,
@@ -248,9 +248,9 @@ class TestCCmis(object):
                 'osnr': 30,
                 'esnr': 16,
                 'cfo': 100,
-                'tx_curr_power': -10,
-                'rx_tot_power': -10,
-                'rx_sig_power': -10,
+                'txcurrpower': -10,
+                'rxtotpower': -10,
+                'rxsigpower': -10,
                 'laser_config_freq': 193100,
                 'laser_curr_freq': 193100,
                 'tx_config_power': -10
@@ -282,6 +282,7 @@ class TestCCmis(object):
                     'lasertemphighalarm': 80, 'lasertemplowalarm': 10, 'lasertemphighwarning': 75, 'lasertemplowwarning': 20,
                     'prefecberhighalarm': 0.0125, 'prefecberlowalarm': 0, 'prefecberhighwarning': 0.01, 'prefecberlowwarning': 0,
                     'postfecberhighalarm': 1, 'postfecberlowalarm': 0, 'postfecberhighwarning': 1, 'postfecberlowwarning': 0,
+                    'soprochighalarm' : 65535, 'soproclowalarm' : 0, 'soprochighwarning' : 65535, 'soproclowwarning' : 0,
                 },
                 {
                     'Pre-FEC BER Average Media Input':{1:[0.001, 0.0125, 0, 0.01, 0, False, False, False, False]},
@@ -296,13 +297,13 @@ class TestCCmis(object):
                     'CD low granularity, long link [ps/nm]':{1:[1000, 2000, 0, 1800, 0, False, False, False, False]},
                     'DGD [ps]':{1:[5, 30, 0, 25, 0, False, False, False, False]},
                     'SOPMD [ps^2]':{1:[5, 100, 0, 80, 0, False, False, False, False]},
+                    'SOP ROC [krad/s]':{1: [0, 65535, 0, 65535, 0, False, False, False, False]},
                     'PDL [dB]':{1:[0.5, 3, 0, 2.5, 0, False, False, False, False]},
                     'OSNR [dB]':{1:[30, 100, 26, 80, 27, False, False, False, False]},
                     'eSNR [dB]':{1:[16, 100, 13, 80, 14, False, False, False, False]},
                     'CFO [MHz]':{1:[100, 5000, -5000, 4000, -4000, False, False, False, False]},
                     'Tx Power [dBm]':{1:[-10, 0, -18, -2, -16, False, False, False, False]},
                     'Rx Total Power [dBm]':{1:[-10, 3, -18, 0, -15, False, False, False, False]},
-                    'Rx Signal Power [dBm]':{1:[-10, 3, -18, 0, -15, False, False, False, False]}
                 }
             ],
             {
@@ -330,7 +331,8 @@ class TestCCmis(object):
                 'cfohighalarm': 5000, 'cfolowalarm': -5000, 'cfohighwarning': 4000, 'cfolowwarning': -4000,
                 'txcurrpowerhighalarm': 0, 'txcurrpowerlowalarm': -18, 'txcurrpowerhighwarning': -2, 'txcurrpowerlowwarning': -16,
                 'rxtotpowerhighalarm': 3, 'rxtotpowerlowalarm': -18, 'rxtotpowerhighwarning': 0, 'rxtotpowerlowwarning': -15,
-                'rxsigpowerhighalarm': 3, 'rxsigpowerlowalarm': -18, 'rxsigpowerhighwarning': 0, 'rxsigpowerlowwarning': -15
+                'rxsigpowerhighalarm': 'N/A', 'rxsigpowerlowalarm': 'N/A', 'rxsigpowerhighwarning': 'N/A', 'rxsigpowerlowwarning': 'N/A',
+                'soprochighalarm': 65535, 'soproclowalarm': 0, 'soprochighwarning': 65535, 'soproclowwarning': 0
             }
         )
     ])
@@ -418,6 +420,8 @@ class TestCCmis(object):
                     'prefecberhighwarning_flag': False, 'prefecberlowwarning_flag': False,
                     'postfecberhighalarm_flag': False, 'postfecberlowalarm_flag': False, 
                     'postfecberhighwarning_flag': False, 'postfecberlowwarning_flag': False,
+                    'soprochighalarm_flag' : False, 'soproclowalarm_flag' : False,
+                    'soprochighwarning_flag' : False, 'soproclowwarning_flag' : False,
                 },
                 False, False, ['TuningComplete'],
                 {
@@ -433,6 +437,7 @@ class TestCCmis(object):
                     'CD low granularity, long link [ps/nm]':{1:[1000, 2000, 0, 1800, 0, False, False, False, False]},
                     'DGD [ps]':{1:[5, 30, 0, 25, 0, False, False, False, False]},
                     'SOPMD [ps^2]':{1:[5, 100, 0, 80, 0, False, False, False, False]},
+                    'SOP ROC [krad/s]':{1: [0, 65535, 0, 65535, 0, False, False, False, False]},
                     'PDL [dB]':{1:[0.5, 3, 0, 2.5, 0, False, False, False, False]},
                     'OSNR [dB]':{1:[30, 100, 26, 80, 27, False, False, False, False]},
                     'eSNR [dB]':{1:[16, 100, 13, 80, 14, False, False, False, False]},
@@ -557,7 +562,8 @@ class TestCCmis(object):
                 'rxtotpowerhighwarning_flag': False, 'rxtotpowerlowwarning_flag': False,
                 'rxsigpowerhighalarm_flag': False, 'rxsigpowerlowalarm_flag': False, 
                 'rxsigpowerhighwarning_flag': False, 'rxsigpowerlowwarning_flag': False,
-                
+                'soprochighalarm_flag' : False, 'soproclowalarm_flag' : False,
+                'soprochighwarning_flag' : False, 'soproclowwarning_flag' : False
             }
         )
     ])
@@ -571,15 +577,6 @@ class TestCCmis(object):
         self.api.get_laser_tuning_summary = MagicMock()
         self.api.get_laser_tuning_summary.return_value = mock_response[3]
         self.api.vdm_dict = mock_response[4]
-        result = self.api.get_transceiver_status()
-        assert result == expected
-
-        # For the case of 'Rx Signal Power [dBm]' not present:
-        get_transceiver_status_func.return_value = dict(mock_response[0])
-        del self.api.vdm_dict['Rx Signal Power [dBm]']
-        for k in ['rxsigpowerhighalarm_flag', 'rxsigpowerlowalarm_flag',
-                  'rxsigpowerhighwarning_flag', 'rxsigpowerlowwarning_flag']:
-            del expected[k]
         result = self.api.get_transceiver_status()
         assert result == expected
 

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -1294,9 +1294,7 @@ class TestCmis(object):
                 'nominal_bit_rate': 0,
                 'specification_compliance': 'sm_media_interface',
                 'application_advertisement': 'N/A',
-                'active_firmware': '0.3.0',
                 'media_lane_count': 1,
-                'inactive_firmware': '0.2.0',
                 'vendor_rev': '0.0',
                 'host_electrical_interface': '400GAUI-8 C2M (Annex 120E)',
                 'vendor_oui': 'xx-xx-xx',
@@ -2374,13 +2372,19 @@ class TestCmis(object):
                 assert 0, traceback.format_exc()
             run_num -= 1
 
-    def test_get_transceiver_info_firmware_versions_negative_tests(self):
+    def test_get_transceiver_info_firmware_versions(self):
         self.api.get_module_fw_info = MagicMock()
         self.api.get_module_fw_info.return_value = None
+        expected_result = {"active_firmware" : "N/A", "inactive_firmware" : "N/A"}
         result = self.api.get_transceiver_info_firmware_versions()
-        assert result == ["N/A", "N/A"]
+        assert result == expected_result
 
         self.api.get_module_fw_info = MagicMock()
         self.api.get_module_fw_info.side_effect = {'result': TypeError}
         result = self.api.get_transceiver_info_firmware_versions()
-        assert result == ["N/A", "N/A"]
+        assert result == expected_result
+
+        expected_result = {"active_firmware" : "2.0.0", "inactive_firmware" : "1.0.0"}
+        self.api.get_module_fw_info.side_effect = [{'result': ( '', '', '', '', '', '', '', '','2.0.0', '1.0.0')}]
+        result = self.api.get_transceiver_info_firmware_versions()
+        assert result == expected_result

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -32,6 +32,19 @@ class TestCmis(object):
         result = self.api.get_model()
         assert result == expected
 
+    def test_get_cable_length_type(self):
+        assert self.api.get_cable_length_type() == "Length Cable Assembly(m)"
+
+    @pytest.mark.parametrize("mock_response, expected", [
+        ("0.0", "0.0"),
+        ("1.2", "1.2")
+    ])
+    def test_get_cable_length(self, mock_response, expected):
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.return_value = mock_response
+        result = self.api.get_cable_length()
+        assert result == expected
+
     @pytest.mark.parametrize("mock_response, expected", [
         ("0.0", "0.0"),
         ("1.2", "1.2")

--- a/tests/sonic_xcvr/test_cmis.py
+++ b/tests/sonic_xcvr/test_cmis.py
@@ -2172,6 +2172,91 @@ class TestCmis(object):
         assert result[1]['host_lane_assignment_options'] == 0x01
         assert result[1]['media_lane_assignment_options'] == 0x02
 
+    def test_get_application_advertisement_apps_with_missing_data(self):
+        self.api.xcvr_eeprom.read = MagicMock()
+        self.api.xcvr_eeprom.read.side_effect = [
+            {
+                consts.HOST_ELECTRICAL_INTERFACE + "_1": "400GAUI-8 C2M (Annex 120E)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_2": None,
+                consts.HOST_ELECTRICAL_INTERFACE + "_3": "200GAUI-8 C2M (Annex 120C)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_4": "40GBASE-CR4 (Clause 85)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_5": "50GBASE-CR (Clause 126)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_6": "200GBASE-CR4 (Clause 136)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_7": "200GAUI-2-S C2M (Annex 120G)",
+                consts.HOST_ELECTRICAL_INTERFACE + "_8": "800G S C2M (placeholder)",
+
+                consts.MODULE_MEDIA_INTERFACE_SM + "_1": "400GBASE-DR4 (Cl 124)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_2": "25GBASE-LR (Cl 114)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_3": "40GBASE-LR4 (Cl 87)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_4": None,
+                consts.MODULE_MEDIA_INTERFACE_SM + "_5": "10GBASE-LR (Cl 52)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_6": "50GBASE-FR (Cl 139)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_7": "100GBASE-DR (Cl 140)",
+                consts.MODULE_MEDIA_INTERFACE_SM + "_8": "800GBASE-DR8 (placeholder)",
+
+                consts.MEDIA_LANE_COUNT + "_1": 4,
+                consts.MEDIA_LANE_COUNT + "_2": 4,
+                consts.MEDIA_LANE_COUNT + "_3": 4,
+                consts.MEDIA_LANE_COUNT + "_4": 4,
+                consts.MEDIA_LANE_COUNT + "_5": None,
+                consts.MEDIA_LANE_COUNT + "_6": 4,
+                consts.MEDIA_LANE_COUNT + "_7": 4,
+                consts.MEDIA_LANE_COUNT + "_8": 4,
+
+                consts.HOST_LANE_COUNT + "_1": 8,
+                consts.HOST_LANE_COUNT + "_2": 8,
+                consts.HOST_LANE_COUNT + "_3": 8,
+                consts.HOST_LANE_COUNT + "_4": 8,
+                consts.HOST_LANE_COUNT + "_5": 8,
+                consts.HOST_LANE_COUNT + "_6": 8,
+                consts.HOST_LANE_COUNT + "_7": 8,
+                consts.HOST_LANE_COUNT + "_8": None,
+
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_1": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_2": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_3": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_4": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_5": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_6": 0x01,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_7": None,
+                consts.HOST_LANE_ASSIGNMENT_OPTION + "_8": 0x01,
+
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_1": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_2": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_3": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_4": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_5": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_6": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_7": 0x02,
+                consts.MEDIA_LANE_ASSIGNMENT_OPTION + "_8": 0x02
+            },
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            None,
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            Sff8024.MODULE_MEDIA_TYPE[2],
+            Sff8024.MODULE_MEDIA_TYPE[2]
+        ]
+        result = self.api.get_application_advertisement()
+
+        assert len(result) == 2
+
+        assert result[1]['host_electrical_interface_id'] == '400GAUI-8 C2M (Annex 120E)'
+        assert result[1]['module_media_interface_id'] == '400GBASE-DR4 (Cl 124)'
+        assert result[1]['host_lane_count'] == 8
+        assert result[1]['media_lane_count'] == 4
+        assert result[1]['host_lane_assignment_options'] == 0x01
+        assert result[1]['media_lane_assignment_options'] == 0x02
+
+        assert result[6]['host_electrical_interface_id'] == '200GBASE-CR4 (Clause 136)'
+        assert result[6]['module_media_interface_id'] == '50GBASE-FR (Cl 139)'
+        assert result[6]['host_lane_count'] == 8
+        assert result[6]['media_lane_count'] == 4
+        assert result[6]['host_lane_assignment_options'] == 0x01
+        assert result[6]['media_lane_assignment_options'] == 0x02
+
     def test_get_application_advertisement_non_support(self):
         self.api.xcvr_eeprom.read = MagicMock(return_value = None)
         self.api.is_flat_memory = MagicMock(return_value = False)

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -1,3 +1,4 @@
+from unittest.mock import mock_open
 from mock import MagicMock 
 from mock import patch 
 import pytest 
@@ -79,3 +80,36 @@ class TestSfpOptoeBase(object):
         result = self.sfp_optoe_api.get_vdm_unfreeze_status()
         assert result == expected
 
+    @patch("builtins.open", new_callable=mock_open)
+    @patch.object(SfpOptoeBase, 'get_eeprom_path')
+    def test_set_optoe_write_timeout_success(self, mock_get_eeprom_path, mock_open):
+        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
+        expected_path = "/sys/bus/i2c/devices/1-0050/write_timeout"
+        expected_timeout = 1
+
+        self.sfp_optoe_api.set_optoe_write_timeout(expected_timeout)
+
+        mock_open.assert_called_once_with(expected_path, mode='w')
+        mock_open().write.assert_called_once_with(str(expected_timeout))
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch.object(SfpOptoeBase, 'get_eeprom_path')
+    def test_set_optoe_write_timeout_ioerror(self, mock_get_eeprom_path, mock_open):
+        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
+        expected_timeout = 1
+        mock_open.side_effect = IOError
+
+        self.sfp_optoe_api.set_optoe_write_timeout(expected_timeout)
+
+        mock_open.assert_called()
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch.object(SfpOptoeBase, 'get_eeprom_path')
+    def test_set_optoe_write_timeout_oserror(self, mock_get_eeprom_path, mock_open):
+        mock_get_eeprom_path.return_value = "/sys/bus/i2c/devices/1-0050/eeprom"
+        expected_timeout = 1
+        mock_open.side_effect = OSError
+
+        self.sfp_optoe_api.set_optoe_write_timeout(expected_timeout)
+
+        mock_open.assert_called()

--- a/tests/ssd_generic_test.py
+++ b/tests/ssd_generic_test.py
@@ -774,6 +774,96 @@ Selective self-test flags (0x0):
 If Selective self-test is pending on power-up, resume after 0 minute delay.
 """
 
+output_wdc_vendor = """
+smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.10.0-18-2-amd64] (local build)
+Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org
+
+=== START OF INFORMATION SECTION ===
+Device Model:     WDC PC SA530 SDASN8Y1T00
+Serial Number:    2122FF441406
+LU WWN Device Id: 5 001b44 4a7dc5677
+Firmware Version: 40103000
+User Capacity:    1,024,209,543,168 bytes [1.02 TB]
+Sector Size:      512 bytes logical/physical
+Rotation Rate:    Solid State Device
+Form Factor:      M.2
+TRIM Command:     Available, deterministic, zeroed
+Device is:        Not in smartctl database [for details use: -P showall]
+ATA Version is:   ACS-4 T13/BSR INCITS 529 revision 5
+SATA Version is:  SATA 3.3, 6.0 Gb/s (current: 6.0 Gb/s)
+Local Time is:    Thu Feb 15 14:12:34 2024 UTC
+SMART support is: Available - device has SMART capability.
+SMART support is: Enabled
+
+=== START OF READ SMART DATA SECTION ===
+SMART overall-health self-assessment test result: PASSED
+
+General SMART Values:
+Offline data collection status:  (0x00) Offline data collection activity
+                                        was never started.
+                                        Auto Offline Data Collection: Disabled.
+Self-test execution status:      (   0) The previous self-test routine completed
+                                        without error or no self-test has ever
+                                        been run.
+Total time to complete Offline
+data collection:                 (   0) seconds.
+Offline data collection
+capabilities:                    (0x11) SMART execute Offline immediate.
+                                        No Auto Offline data collection support.
+                                        Suspend Offline collection upon new
+                                        command.
+                                        No Offline surface scan supported.
+                                        Self-test supported.
+                                        No Conveyance Self-test supported.
+                                        No Selective Self-test supported.
+SMART capabilities:            (0x0003) Saves SMART data before entering
+                                        power-saving mode.
+                                        Supports SMART auto save timer.
+Error logging capability:        (0x01) Error logging supported.
+                                        General Purpose Logging supported.
+Short self-test routine
+recommended polling time:        (   2) minutes.
+Extended self-test routine
+recommended polling time:        (  10) minutes.
+
+SMART Attributes Data Structure revision number: 4
+Vendor Specific SMART Attributes with Thresholds:
+ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
+  5 Reallocated_Sector_Ct   0x0032   100   100   ---    Old_age   Always       -       0
+  9 Power_On_Hours          0x0032   100   100   ---    Old_age   Always       -       18904
+ 12 Power_Cycle_Count       0x0032   100   100   ---    Old_age   Always       -       169
+165 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       28311878
+166 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       1
+167 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       54
+168 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       10
+169 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       361
+170 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       0
+171 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       0
+172 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       0
+173 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       5
+174 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       61
+184 End-to-End_Error        0x0032   100   100   ---    Old_age   Always       -       0
+187 Reported_Uncorrect      0x0032   100   100   ---    Old_age   Always       -       0
+188 Command_Timeout         0x0032   100   100   ---    Old_age   Always       -       0
+194 Temperature_Celsius     0x0022   077   059   ---    Old_age   Always       -       23 (Min/Max 16/59)
+199 UDMA_CRC_Error_Count    0x0032   100   100   ---    Old_age   Always       -       0
+230 Unknown_SSD_Attribute   0x0032   001   001   ---    Old_age   Always       -       279176151105
+232 Available_Reservd_Space 0x0033   100   100   004    Pre-fail  Always       -       100
+233 Media_Wearout_Indicator 0x0032   100   100   ---    Old_age   Always       -       5374
+234 Unknown_Attribute       0x0032   100   100   ---    Old_age   Always       -       7530
+241 Total_LBAs_Written      0x0030   253   253   ---    Old_age   Offline      -       6756
+242 Total_LBAs_Read         0x0030   253   253   ---    Old_age   Offline      -       963
+244 Unknown_Attribute       0x0032   000   100   ---    Old_age   Always       -       0
+
+SMART Error Log Version: 1
+No Errors Logged
+
+SMART Self-test log structure revision number 1
+No self-tests have been logged.  [To run self-tests, use: smartctl -t]
+
+Selective Self-tests/Logging not supported
+"""
+
 class TestSsdGeneric:
     @mock.patch('sonic_platform_base.sonic_ssd.ssd_generic.SsdUtil._execute_shell', mock.MagicMock(return_value=output_nvme_ssd))
     def test_nvme_ssd(self):
@@ -891,3 +981,13 @@ class TestSsdGeneric:
         assert swissbit_ssd.get_firmware() == "SBR15004"
         assert swissbit_ssd.get_temperature() == '25'
         assert swissbit_ssd.get_serial() == "00006022750795000010"
+
+    @mock.patch('sonic_platform_base.sonic_ssd.ssd_generic.SsdUtil._execute_shell')
+    def test_wdc_ssd(self, mock_exec):
+        mock_exec.return_value = output_wdc_vendor
+        wdc_ssd = SsdUtil('/dev/sda')
+        assert wdc_ssd.get_health() == 98
+        assert wdc_ssd.get_model() == 'WDC PC SA530 SDASN8Y1T00'
+        assert wdc_ssd.get_firmware() == "40103000"
+        assert wdc_ssd.get_temperature() == '23'
+        assert wdc_ssd.get_serial() == "2122FF441406"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Issue:
Reading the firmware version on specific CMIS transceivers in xcvrd can take up to 60 seconds, causing delays that lead to port breakout failures.

Solution:
Reduce the maximum firmware read timeout from 60 seconds to 10 seconds to improve responsiveness and avoid port breakout issues.

Note:
1. The firmware read timeout mentioned above is also called CDB which is
   defined in CMIS.
2. The issue happens under the condition that the xcvr's CDB takes long
   time to response, and several dynamic port breakout mode commands are
   issued with a short internal.
3. The CDB timeout 60 seconds will block the xcvrd thread and result in
   the situation that the work for the previous port breakout mode is not
   done yet but the new port breakout mode is applied.
4. It takes too much effort and is not worthy to handle such condition.
   So simply reduce the timeout to a more reasonable value to avoid
   the error.


#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

