### PR TITLE
JIRA-SONIC-13444: [CMIS] [LUMENTUM] Support OSFP-ZR

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -779,6 +779,14 @@ class CmisApi(XcvrApi):
         duration = self.xcvr_eeprom.read(consts.MODULE_PWRDN_DURATION)
         return float(duration) if duration is not None else 0
 
+    def is_tx_tunable(self):
+        '''
+        Returns True if transmitter is tunable(Page04h and 12h supported)
+        '''
+        if self.is_flat_memory():
+            return False
+        return self.xcvr_eeprom.read(consts.TX_TUNABLE_SUPPORT_FIELD)
+
     def get_host_lane_count(self):
         '''
         This function returns number of host lanes for default application

--- a/sonic_platform_base/sonic_xcvr/fields/consts.py
+++ b/sonic_platform_base/sonic_xcvr/fields/consts.py
@@ -55,6 +55,7 @@ TX_FAULT_FIELD = "TxFault"
 TX_FAULT_SUPPORT_FIELD = "TxFaultSupported"
 TX_DISABLE_FIELD = "TxDisable"
 TX_DISABLE_SUPPORT_FIELD = "TxDisableSupported"
+TX_TUNABLE_SUPPORT_FIELD = "TxTunableSupported"
 
 TX_POWER_FIELD = "TxPower"
 TX_POWER_SUPPORT_FIELD = "TxPowerSupported"

--- a/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/mem_maps/public/cmis.py
@@ -213,6 +213,7 @@ class CmisMemMap(XcvrMemMap):
             ),
             NumberRegField(consts.CTRLS_ADVT_FIELD, self.getaddr(0x1, 155),
                 RegBitField(consts.TX_DISABLE_SUPPORT_FIELD, 1),
+                RegBitField(consts.TX_TUNABLE_SUPPORT_FIELD, 6),
                 size=2, format="<H"
             ),
             NumberRegField(consts.TX_FLAGS_ADVT_FIELD, self.getaddr(0x1, 157),

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -85,7 +85,7 @@ class XcvrApiFactory(object):
                 xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
                 api = CmisApi(xcvr_eeprom)
 
-            if api.is_coherent_module():
+            if api.is_tx_tunable():
                 mem_map = CCmisMemMap(codes)
                 xcvr_eeprom = XcvrEeprom(self.reader, self.writer, mem_map)
                 api = CCmisApi(xcvr_eeprom)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
The api is_coherent_module can't determeter the OSFP-ZR correctly. Use the proper CMIS-compliant method to define whether frequency tuning is supported.


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

