### PR TITLE
CMIS application cannnot be parsing for unknown Media Interface

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/cmis.py
@@ -2059,7 +2059,7 @@ class CmisApi(XcvrApi):
 
             key = "{}_{}".format(consts.HOST_ELECTRICAL_INTERFACE, app)
             val = dic.get(key)
-            if val in [None, 'Unknown', 'Undefined']:
+            if val in [None, 'End']:
                 continue
             buf['host_electrical_interface_id'] = val
 
@@ -2068,7 +2068,7 @@ class CmisApi(XcvrApi):
                 continue
             key = "{}_{}".format(prefix, app)
             val = dic.get(key)
-            if val in [None, 'Unknown']:
+            if val in [None]:
                 continue
             buf['module_media_interface_id'] = val
 

--- a/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
+++ b/sonic_platform_base/sonic_xcvr/codes/public/sff8024.py
@@ -267,7 +267,8 @@ class Sff8024(XcvrCodes):
         80: '400GAUI-4-L C2M (Annex 120G)',
         81: '800G S C2M (placeholder)',
         82: '800G L C2M (placeholder)',
-        83: 'OTL4.2'
+        83: 'OTL4.2',
+       255: 'End'
     }
 
     # MMF media interface IDs
@@ -387,7 +388,12 @@ class Sff8024(XcvrCodes):
         84: 'FOIC2.4-DO (G.709.3/Y.1331.3)',
         85: '400GBASE-DR4-2 (placeholder)',
         86: '800GBASE-DR8 (placeholder)',
-        87: '800GBASE-DR8-2 (placeholder)'
+        87: '800GBASE-DR8-2 (placeholder)',
+        102: 'FLEXO-8e-DO-16QAM/FOIC8e.8-DO',
+        151: "100G-DR1-LPO",
+        152: "200G-DR2-LPO",
+        153: "400G-DR4-LPO",
+        154: "800G-DR8-LPO",
     }
 
     # Passive and Linear Active Copper Cable and Passive Loopback media interface codes

--- a/sonic_platform_base/sonic_xcvr/fields/xcvr_field.py
+++ b/sonic_platform_base/sonic_xcvr/fields/xcvr_field.py
@@ -238,7 +238,7 @@ class CodeRegField(RegField):
         if mask is not None:
             code &= mask
             code >>= self.start_bitpos
-        return self.code_dict.get(code, "Unknown")
+        return self.code_dict.get(code, "Unknown: {}".format(code))
 
 class HexRegField(RegField):
     """


### PR DESCRIPTION
The original code would skip parsing the advertised application if the interface was unknown. The application advertisement would show 'N/A' if the media interface is unknown.

Enhance:
1. Show the unknown ID
2. Add the unknown ID 102 to codes/public/sff8024.py

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)

